### PR TITLE
Update image path to conform with the new naming convention

### DIFF
--- a/.github/workflows/proofs.yml
+++ b/.github/workflows/proofs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Prove MPS Components
         uses: addnab/docker-run-action@v3
         with:
-          image: ghcr.io/galoisinc/cerberus:release
+          image: ghcr.io/galoisinc/verse-opensut/cerberus:release
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.VERSE_OPENSUT_ACCESS_TOKEN }}


### PR DESCRIPTION
Necessary after fed6ccac25edc4825e98f8afe56d7c2c9c3619dc