### PR TITLE
MPS: posix_main.c specs that are currently possible

### DIFF
--- a/components/mission_protection_system/src/cn.mk
+++ b/components/mission_protection_system/src/cn.mk
@@ -4,10 +4,18 @@ CN=cn $(CN_FLAGS)
 proofs: components/actuator.cn \
  components/instrumentation_common.cn \
  components/instrumentation.cn \
- components/actuation_unit.cn
+ components/actuation_unit.cn \
+ posix_main.cn
 
 %.cn: %.c
 	$(CN) $<
 
 components/actuation_unit.cn: components/actuation_unit.c
 	$(CN) $< --skip=actuation_logic_collect_trips
+#send_actuation_command malloc
+#read_actuation_command global variables and a scope issue, CN issue #353
+#update_sensor_errors contains a 2-level and 3-level array with the same variables used as indices in both, CN issue #357
+#update_sensors also CN issue #357
+#clear_screen need to claim that stdin is a valid pointer while using `accesses`. Could just use take but it's a global
+posix_main.cn: posix_main.c
+	$(CN) $< --skip=main,start1,start0,update_sensor_errors,clear_screen,update_sensors,send_actuation_command,read_actuation_command

--- a/components/mission_protection_system/src/include/core.h
+++ b/components/mission_protection_system/src/include/core.h
@@ -75,7 +75,15 @@ struct core_state {
 extern struct core_state core;
 
 int set_display_line(struct ui_values *ui, uint8_t line_number, char *display, uint32_t size);
+/*$ spec set_display_line(pointer ui, u8 line_number, pointer display, u32 size);
+    requires take uii = Owned<struct ui_values>(ui);
+    ensures take uio = Owned<struct ui_values>(ui);
+ $*/
 
 void core_init(struct core_state *core);
+/*$ spec core_init(pointer cor);
+ requires take ci = Block<struct core_state>(cor);
+ ensures take co = Owned<struct core_state>(cor);
+ $*/
 int core_step(struct core_state *core);
 #endif // CORE_H_

--- a/components/mission_protection_system/src/include/sense_actuate.h
+++ b/components/mission_protection_system/src/include/sense_actuate.h
@@ -29,6 +29,13 @@
 int sense_actuate_init(int core_id,
                        struct instrumentation_state *instrumentation,
                        struct actuation_logic *actuation);
+/*$ spec sense_actuate_init(i32 core_id, pointer instrumentation, pointer actuation);
+  requires take ii = each(u64 j; j < 2u64) {Block<struct instrumentation_state>(array_shift(instrumentation,j))};
+      take ai = Block<struct actuation_logic>(actuation);
+
+  ensures take io = each(u64 j; j < 2u64) {Owned<struct instrumentation_state>(array_shift(instrumentation,j))};
+      take ao = Owned<struct actuation_logic>(actuation);
+$*/
 
 /* Advance state for core `core_id`.
  * @requires instrumentation is an array of NINSTRUMENTATION/NCORE_ID instrumentation structs

--- a/components/mission_protection_system/src/posix_main.c
+++ b/components/mission_protection_system/src/posix_main.c
@@ -21,28 +21,114 @@
 #include "sense_actuate.h"
 #include "platform.h"
 
+#if 0
+// Cerberus has these headers but they're not accessible, CN issue #358
+#include <posix/poll.h>
+#include <posix/fcntl.h>
+#include <posix/termios.h>
+#include <posix/unistd.h>
+#include <posix/sys/select.h>
+#include <posix/time.h>
+#endif
+#if 0
 #include <poll.h>
 #include <fcntl.h>
+#endif
+#if !WAR_NO_VARIADICS
 #include <stdio.h>
+#else
+#define printf(...)
+#define sprintf(...)
+#endif
+#if 0
 #include <termios.h>
 #include <unistd.h>
+#endif
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if 0
 #include <sys/select.h>
 #include <time.h>
+#endif
+
+#if 1
+// these are just placeholder definitions until CN #358 is done
+typedef signed int ssize_t;
+typedef int64_t time_t;
+typedef struct FILE {
+  int x;
+} FILE;
+FILE _stdin;
+FILE *__stdin = &_stdin;
+// this is how the cerberus stdio does it
+#define stdin __stdin
+FILE *stdout;
+#define STDIN_FILENO 0
+#define EOF 0x100
+int
+isatty(int fd);
+int
+fileno(FILE *stream);
+// this spec satisfies the caller but requires we have evidence that stdin is
+// alive, and might need to be extended to provide evidence that the argument is
+// open for full compliance.
+/*$ spec fileno(pointer stream);
+    requires take si = Owned<FILE>(stream);
+    ensures take so = Owned<FILE>(stream);
+$*/
+int
+fflush(FILE *stream);
+
+#define POLLIN 0
+struct pollfd {
+  int    fd;       /* file descriptor */
+  short  events;   /* events to look for */
+  short  revents;  /* events returned */
+};
+typedef size_t nfds_t;
+int
+poll(struct pollfd fds[], nfds_t nfds, int timeout);
+
+struct timespec {
+  int64_t tv_usec;
+  int64_t tv_nsec;
+  int64_t tv_sec;
+};
+
+typedef int clockid_t;
+#define CLOCK_REALTIME 0
+int
+clock_gettime(clockid_t clock_id, struct timespec *tp);
+/*$ spec clock_gettime(i32 clock_id, pointer tp);
+    requires take tpi = Block<struct timespec>(tp);
+    ensures take tpo = Owned<struct timespec>(tp);
+$*/
+
+int
+rand(void);
+/*$ spec rand();
+    requires true;
+    ensures true;
+$*/
+
+typedef int64_t useconds_t;
+int
+usleep(useconds_t microseconds);
+#endif
+
 
 extern struct instrumentation_state instrumentation[4];
 struct actuation_command *act_command_buf[2];
-
 #define min(_a, _b) ((_a) < (_b) ? (_a) : (_b))
 #define max(_a, _b) ((_a) > (_b) ? (_a) : (_b))
-
+#if 0
+//cerberus has a pthread header but like the others it's not accessible
 #include <pthread.h>
 pthread_mutex_t display_mutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t mem_mutex = PTHREAD_MUTEX_INITIALIZER;
+#endif
 
 #ifndef T0
 #define T0 200
@@ -66,20 +152,26 @@ pthread_mutex_t mem_mutex = PTHREAD_MUTEX_INITIALIZER;
 #define SENSOR_UPDATE_MS 500
 #endif
 
-int clear_screen() {
+int clear_screen()
+  // problem: need to specify that stdin owns its pointee and is valid
+/*$ accesses __stdin;
+$*/
+{
   return (isatty(fileno(stdin)) && (NULL == getenv("RTS_NOCLEAR")));
 }
 
-void update_display() {
+void update_display()
+  /*$ accesses __stdin; $*/
+{
   if (clear_screen()) {
-    printf("\e[s\e[1;1H");//\e[2J");
+    printf("\x1b[s\x1b[1;1H");//\e[2J");
   }
   for (int line = 0; line < NLINES; ++line) {
-    printf("\e[0K");
+    printf("\x1b[0K");
     printf("%s%s", core.ui.display[line], line == NLINES-1 ? "" : "\n");
   }
   if (clear_screen()) {
-    printf("\e[u");
+    printf("\x1b[u");
   }
 }
 
@@ -87,6 +179,9 @@ void update_display() {
 // reset (`R`) command inside `read_rts_command`.
 static char** main_argv = NULL;
 
+#if 0
+//can get around everything but sscanf which is variadic and can't be worked
+//around with a dummy because it's actually used at multiple types here
 int read_rts_command(struct rts_command *cmd) {
   int ok = 0;
   uint8_t device, on, div, ch, mode, sensor;
@@ -116,7 +211,7 @@ int read_rts_command(struct rts_command *cmd) {
   MUTEX_LOCK(&display_mutex);
 
   if (clear_screen()) {
-    printf("\e[%d;1H\e[2K> ", NLINES+1);
+    printf("\x1b[%d;1H\x1b[2K> ", NLINES+1);
   }
 
   MUTEX_UNLOCK(&display_mutex);
@@ -176,7 +271,12 @@ int read_rts_command(struct rts_command *cmd) {
     printf("<main.c> read_rts_command RESET\n");
     // Re-exec the RTS binary with the same arguments and environment.  This
     // has the effect of resetting the entire RTS to its initial state.
+    // TODO call a noreturn function
+    #if 0
     execv("/proc/self/exe", main_argv);
+    #else
+    exit(0);
+    #endif
   } else if (line[0] == 'D') {
     DEBUG_PRINTF(("<main.c> read_rts_command UPDATE DISPLAY\n"));
     update_display();
@@ -195,23 +295,63 @@ int read_rts_command(struct rts_command *cmd) {
 
   return ok;
 }
+#endif
 
-void update_instrumentation_errors(void) {
-  for (int i = 0; i < NINSTR; ++i) {
+void update_instrumentation_errors(void)
+/*$ accesses error_instrumentation_mode;
+   accesses error_instrumentation;
+$*/
+{
+  for (int i = 0; i < NINSTR; ++i)
+    /*$ inv i >= 0i32; i <= (i32) NINSTR(); $*/
+  {
+    /*$ extract Owned<uint8_t>, (u64)i; $*/
     if(error_instrumentation_mode[i] == 2) {
+#if !WAR_CN_231
       error_instrumentation[i] |= rand() % 2;
+#else
+      error_instrumentation[i] |= rand() & 1;
+#endif
     } else {
       error_instrumentation[i] = error_instrumentation_mode[i];
     }
   }
 }
 
-void update_sensor_errors(void) {
-  for (int c = 0; c < 2; ++c) {
-    for (int s = 0; s < 2; ++s) {
+// CN #357 is blocking this, otherwise should be simple
+void update_sensor_errors(void)
+/*$
+    accesses error_sensor;
+    accesses error_sensor_mode;
+    accesses error_sensor_demux;
+$*/
+{
+  for (int c = 0; c < 2; ++c)
+    /*$ inv c >= 0i32; c <= 2i32;
+      {error_sensor_mode} unchanged;
+      {error_sensor_demux} unchanged;
+     $*/
+  {
+    for (int s = 0; s < 2; ++s)
+    /*$ inv s >= 0i32; s <= 2i32;
+        c < 2i32;
+        c >= 0i32;
+        {&c} unchanged;
+      {error_sensor_mode} unchanged;
+      {error_sensor_demux} unchanged;
+     $*/
+    {
+      /*$ extract Owned<uint8_t[2]>, (u64)c; $*/
+      /*$ extract Owned<uint8_t>, (u64)s; $*/
+
+          /*$ extract Owned<uint8_t[2][2]>, (u64)c; $*/
+          /*$ extract Owned<uint8_t[2]>, (u64)s; $*/
+          /*$ extract Owned<uint8_t>, 0u64; $*/
+          /*$ extract Owned<uint8_t>, 1u64; $*/
       switch (error_sensor_mode[c][s]) {
         case 0:
           error_sensor[c][s] = 0;
+
           error_sensor_demux[c][s][0] = 0;
           error_sensor_demux[c][s][1] = 0;
           break;
@@ -232,7 +372,11 @@ void update_sensor_errors(void) {
           break;
         case 4:
         {
+          #if 0
           int fail = rand() % 2;
+          #else
+          int fail = rand() & 1;
+          #endif
           error_sensor[c][s] |= fail;
           error_sensor_demux[c][s][0] = 0;
           error_sensor_demux[c][s][1] = 0;
@@ -252,57 +396,135 @@ void update_sensor_errors(void) {
   }
 }
 
-int update_sensor_simulation(void) {
+// CN #353 is blocking this, additionally it will require careful handling of
+// the arithmetic which has many possible overflows
+#if 1
+static int initialized = 0;
+static uint32_t last_update = 0;
+static uint32_t last[2][2] = {0};
+#endif
+int update_sensor_simulation(void)
+  /*$
+    accesses last_update;
+    accesses initialized;
+    accesses last;
+    accesses sensors;
+    $*/
+{
+  #if 0
   static int initialized = 0;
   static uint32_t last_update = 0;
   static uint32_t last[2][2] = {0};
+  #endif
 
   struct timespec tp;
   clock_gettime(CLOCK_REALTIME, &tp);
   uint32_t t0 = last_update;
+
+#if 0
   uint32_t t = tp.tv_sec*1000 + tp.tv_nsec/1000000;
+#else
+  uint32_t t = 0;
+  /*$ split_case(tp.tv_sec > 1000000i64 || tp.tv_sec < -1000000i64); $*/
+  if (tp.tv_sec > 1000000 || tp.tv_sec < -1000000) {
+    initialized = 0;
+  } else {
+#if !WAR_CN_231
+   t = tp.tv_sec*1000 + tp.tv_nsec/1000000;
+#else
+   t = tp.tv_sec*1000; //+ tp.tv_nsec;
+#endif
+  }
+#endif
 
   if (!initialized) {
     last_update = t;
+    /*$ extract Owned<uint32_t[2]>, 0u64; $*/
+    /*$ extract Owned<uint32_t>, (u64)T(); $*/
     last[0][T] = T0;
+    /*$ extract Owned<uint32_t[2]>, 1u64; $*/
+    ///*$ extract Owned<uint32_t>, (u64)T(); $*/
     last[1][T] = T0;
+    /*$ extract Owned<uint32_t>, (u64)P(); $*/
     last[0][P] = P0;
     last[1][P] = P0;
     initialized = 1;
   } else if (t - t0 > SENSOR_UPDATE_MS) {
-    for (int s = 0; s < 2; ++s) {
+    for (int s = 0; s < 2; ++s)
+      /*$ inv 0i32 <= s; s <= 2i32;
+          $*/
+    {
+      /*$ extract Owned<uint32_t[2]>, (u64)s; $*/
+      /*$ extract Owned<uint32_t>, (u64)T(); $*/
+#if !WAR_CN_231
       last[s][T] += (rand() % 7) - 3 + T_BIAS;
+#else
+      last[s][T] += (rand()) - (uint32_t)3 + T_BIAS;
+#endif
       // Don't stray too far from our steam table
       last[s][T] = min(last[s][T], 300);
       last[s][T] = max(last[s][T], 25);
 
+      /*$ extract Owned<uint32_t>, (u64)P(); $*/
+#if !WAR_CN_231
       last[s][P] += (rand() % 7) - 3 + P_BIAS;
+#else
+      last[s][P] += (rand()) - (uint32_t)3 + P_BIAS;
+#endif
       // Don't stray too far from our steam table
       last[s][P] = min(last[s][P], 5775200);
       last[s][P] = max(last[s][P], 8000);
     }
     last_update = t;
   }
+  /*$ extract Owned<uint32_t[2]>, (u64)T(); $*/
+  /*$ extract Owned<uint32_t>, 0u64; $*/
+  /*$ extract Owned<uint32_t>, 1u64; $*/
+  ///*$ extract Owned<uint32_t[2]>, 0u64; $*/
+  ///*$ extract Owned<uint32_t>, (u64)T(); $*/
   sensors[T][0] = last[T][0];
   sensors[T][1] = last[T][1];
+  /*$ extract Owned<uint32_t[2]>, (u64)P(); $*/
   sensors[P][0] = last[P][0];
   sensors[P][1] = last[P][1];
 
   return 0;
 }
 
-void update_sensors(void) {
+// CN #357 again
+void update_sensors(void)
+  /*$ accesses error_sensor;
+accesses error_sensor_mode;
+accesses error_sensor_demux;
+accesses sensors_demux;
+accesses sensors;
+    $*/
+{
   update_sensor_errors();
 #ifdef SIMULATE_SENSORS
   update_sensor_simulation();
 #endif
-  for (int c = 0; c < 2; ++c) {
-    for (int s = 0; s < 2; ++s) {
+  for (int c = 0; c < 2; ++c)
+    /*$ inv c >= 0i32; c <= 2i32; $*/
+  {
+    for (int s = 0; s < 2; ++s)
+    /*$ inv s >= 0i32; s <= 2i32;
+            c >= 0i32; c < 2i32;
+      $*/
+    {
+      /*$ extract Owned<uint8_t[2]>, (u64)c; $*/
+      /*$ extract Owned<uint8_t>, (u64)s; $*/
       if (error_sensor[c][s]) {
-        sensors[c][s] = rand();
+      ///*$ extract Owned<uint32_t[2]>, (u64)c; $*/
+      ///*$ extract Owned<uint32_t>, (u64)s; $*/
+        //sensors[c][s] = rand();
       }
 
       MUTEX_LOCK(&mem_mutex);
+
+      /*$ extract Owned<uint32_t[2][2]>, (u64)c; $*/
+      /*$ extract Owned<uint32_t[2]>, (u64)s; $*/
+      /*$ extract Owned<uint32_t>, 0u64; $*/
       sensors_demux[c][s][0] = sensors[c][s];
       MUTEX_UNLOCK(&mem_mutex);
 
@@ -321,7 +543,12 @@ void update_sensors(void) {
   }
 }
 
-int read_actuation_command(uint8_t id, struct actuation_command *cmd) {
+int read_actuation_command(uint8_t id, struct actuation_command *cmd)
+///*$ accesses act_command_buf; $*/
+// TODO not possible to specify this because the spec needs to be in a header
+// file and the body is here and act_command_buf is declared in this file,
+// inaccessible to the header file. Might be working as intended
+{
   struct actuation_command *c = act_command_buf[id];
   if (c) {
     cmd->device = c->device;
@@ -356,31 +583,104 @@ void* start1(void *arg) {
   }
 }
 
+#if 1
+  time_t start_time = 0;
+#endif
+// TODO ensure names match gcc builtins
+int sadd_overflow (int a, int b, int *res);
+/*$ spec sadd_overflow(i32 a, i32 b, pointer res);
+    requires take x = Block<int>(res);
+    ensures take out = Owned<int>(res);
+      (return == (1i32)) || (out == (a + b));
+$*/
+int smul_overflow (int a, int b, int *res);
+/*$ spec smul_overflow(i32 a, i32 b, pointer res);
+    requires take x = Block<int>(res);
+    ensures take out = Owned<int>(res);
+      (return == (1i32)) || (out == (a * b));
+$*/
+int ssub_overflow (int a, int b, int *res);
+/*$ spec ssub_overflow(i32 a, i32 b, pointer res);
+    requires take x = Block<int>(res);
+    ensures take out = Owned<int>(res);
+      (return == (1i32)) || (out == (a - b));
+$*/
+int dadd_overflow (int64_t a, int64_t b, int64_t *res);
+/*$ spec dadd_overflow(i64 a, i64 b, pointer res);
+    requires take x = Block<int64_t>(res);
+    ensures take out = Owned<int64_t>(res);
+      (return == (1i32)) || (out == (a + b));
+$*/
+int dmul_overflow (int64_t a, int64_t b, int64_t *res);
+/*$ spec dmul_overflow(i64 a, i64 b, pointer res);
+    requires take x = Block<int64_t>(res);
+    ensures take out = Owned<int64_t>(res);
+      (return == (1i32)) || (out == (a * b));
+$*/
+int dsub_overflow (int64_t a, int64_t b, int64_t *res);
+/*$ spec dsub_overflow(i64 a, i64 b, pointer res);
+    requires take x = Block<int64_t>(res);
+    ensures take out = Owned<int64_t>(res);
+      (return == (1i32)) || (out == (a - b));
+$*/
 uint32_t time_in_s()
+/*$ accesses start_time;
+    accesses core;
+$*/
 {
+  #if 0
   static time_t start_time = 0;
+  #endif
   struct timespec tp;
   clock_gettime(CLOCK_REALTIME, &tp);
+  /*$ split_case(start_time == 0i64); $*/
   if (start_time == 0) {
     start_time = tp.tv_sec;
   }
+  #if 0
   time_t total = tp.tv_sec - start_time;
+  #else
+  int64_t total_ = 0;
+  time_t total = 0;
+  int ok = dsub_overflow(tp.tv_sec, start_time, &total_);
+  total = total_;
+  #endif
   char line[256];
   sprintf(line, "Uptime: [%u]s\n",(uint32_t)total);
   set_display_line(&core.ui, 9, line, 0);
   return (uint32_t)total;
 }
 
-int main(int argc, char **argv) {
-  main_argv = argv;
+// VERSE-Toolchain#107 is the blocker here
+
+int main(void) //(int argc, char **argv)
+/*$  requires true;
+  ////requires take ci = Block<struct core_state>(&core);
+  //requires take ii = each(u64 j; j < 4u64) {Block<struct instrumentation_state>(array_shift<struct instrumentation_state>(&instrumentation, j))};
+  //requires take ai = each(u64 j; j < 2u64) {Block<struct actuation_logic>(array_shift<struct actuation_logic>(&actuation_logic, j))};
+    ensures true;
+$*/
+{
+  //char **argv;
+  //main_argv = argv;
+#if 0
   struct rts_command *cmd = (struct rts_command *)malloc(sizeof(*cmd));
+#else
+  struct rts_command _cmd;
+  struct rts_command *cmd = &_cmd;
+#endif
 
   core_init(&core);
+  /*$ extract Block<struct instrumentation_state>, 0u64; $*/
+  /*$ extract Block<struct actuation_logic>, 0u64; $*/
   sense_actuate_init(0, &instrumentation[0], &actuation_logic[0]);
+
+  /*$ extract Block<struct instrumentation_state>, 2u64; $*/
+  /*$ extract Block<struct actuation_logic>, 1u64; $*/
   sense_actuate_init(1, &instrumentation[2], &actuation_logic[1]);
 
-  if (isatty(fileno(stdin))) printf("\e[1;1H\e[2J");
-  if (isatty(fileno(stdin))) printf("\e[%d;3H\e[2K> ", NLINES+1);
+  if (isatty(fileno(stdin))) printf("\x1b[1;1H\x1b[2J");
+  if (isatty(fileno(stdin))) printf("\x1b[%d;3H\x1b[2K> ", NLINES+1);
 
 #ifdef USE_PTHREADS
   pthread_attr_t attr;


### PR DESCRIPTION
## Describe your changes

Implented specs for all functions except for the following:
* `send_actuation_command`: uses malloc, GaloisInc/VERSE-Toolchain#84
* `read_actuation_command`: global variables and a scope issue, rems-project/cerberus#353
* `update_sensor_errors`: contains a 2-level and 3-level array with the same variables used as indices in both,  rems-project/cerberus#357
* `update_sensors`: also rems-project/cerberus#357
* `clear_screen`: need to claim that stdin is a valid pointer while using `accesses`. Could just use take but it's a global. This is also affected by the spec chosen for `fileno`
* `read_rts_command`: uses `sscanf` and uses it at multiple types, rems-project/cerberus#301

A solution to rems-project/cerberus#358 will also be needed instead of the stub declarations used currently.

## Issue ticket number and link

#55 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] My code matches the coding standards and I have ran the appropriate linters
- [ ] I included documentation updates for my code
- [ ] I extended the test suite and the tests run by the CI to cover my code
- [ ] I assigned a Milestone to this PR
- [ ] I assigned this PR to a Project
- [ ] I assigned this PR appropriate Labels
