### PR TITLE
ci: run apt-get update before the first install in each job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,9 @@ jobs:
               path: packages/${{ needs.libgpiod.outputs.CACHE_KEY }}.tar.gz
         - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
           name: Install aarch64 toolchain
-          run: sudo apt-get install -y {gcc,g++}-aarch64-linux-gnu
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y {gcc,g++}-aarch64-linux-gnu
         - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
           name: Install verilator
           run: sudo apt-get install -y verilator
@@ -77,7 +79,9 @@ jobs:
           chmod +x mps.*
           mv mps.* components/mission_protection_system/src/.
       - name: Install pip3
-        run: sudo apt-get install -y python3-pip
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pip
       - name: Test MPS
         run: |
           cd components/mission_protection_system/tests
@@ -90,7 +94,9 @@ jobs:
         - name: Checkout repository and submodules
           uses: actions/checkout@v4
         - name: Install aarch64 toolchain
-          run: sudo apt-get install -y {gcc,g++}-aarch64-linux-gnu
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y {gcc,g++}-aarch64-linux-gnu
         - name: Build trusted_boot
           run: |
             cd components/platform_crypto/shave_trusted_boot/
@@ -120,7 +126,9 @@ jobs:
         path: packages/${{ env.CACHE_KEY }}.tar.gz
     - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: Install aarch64 toolchain
-      run: sudo apt-get install -y gcc-aarch64-linux-gnu
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-aarch64-linux-gnu
     - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       uses: hecrj/setup-rust-action@v2
       with:
@@ -156,6 +164,7 @@ jobs:
     - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: Install dependency packages
       run: |
+        sudo apt-get update
         sudo apt-get install -y \
           build-essential autoconf automake autoconf-archive \
           gcc-aarch64-linux-gnu
@@ -198,6 +207,7 @@ jobs:
     - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: Install dependency packages
       run: |
+        sudo apt-get update
         sudo apt-get install -y \
           build-essential autoconf automake autoconf-archive \
           gcc-aarch64-linux-gnu
@@ -360,6 +370,7 @@ jobs:
     - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: Install dependency packages
       run: |
+        sudo apt-get update
         sudo apt-get install -y qemu-system-arm qemu-utils
     - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: Build VM images
@@ -404,7 +415,9 @@ jobs:
       run: |
         tar -xvf packages/${{ needs.vhost_device.outputs.CACHE_KEY }}.tar.gz
     - name: Install QEMU
-      run: sudo apt-get install -y qemu-system-arm
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y qemu-system-arm
     - uses: hecrj/setup-rust-action@v2
       with:
         rust-version: 1.74
@@ -436,6 +449,7 @@ jobs:
         - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
           name: Install dependencies
           run: |
+            sudo apt-get update
             BUILD_ONLY=1 bash components/autopilot/ardupilot_install_deps.sh
         - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
           name: Fetch additional submodules for build
@@ -456,7 +470,9 @@ jobs:
         # jsbsim_proxy is trivial to build, so we don't bother packaging or
         # caching it.
         - name: Install dependencies
-          run: sudo apt install build-essential
+          run: |
+            sudo apt-get update
+            sudo apt install build-essential
         - name: Build jsbsim_proxy
           run: |
               cd src/jsbsim_proxy


### PR DESCRIPTION
This updates `main.yml` to run `sudo apt-get update` before the first `apt-get install` in each CI job.  This should fix the recent CI errors due to packages being not found on the Ubuntu mirrors.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] My code matches the coding standards and I have ran the appropriate linters
- [x] I included documentation updates for my code
- [x] I extended the test suite and the tests run by the CI to cover my code
- [x] I assigned a Milestone to this PR
- [x] I assigned this PR to a Project
- [x] I assigned this PR appropriate Labels
