### PR TITLE
Add a OpenSUT startup script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+src/pkvm_setup/linux-pkvm
+src/pkvm_setup/linux-pkvm-verif

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -628,6 +628,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - mps-build
+    - trusted-boot-build
     - vm_runner
     - libgpiod
     - vhost_device
@@ -636,12 +637,14 @@ jobs:
     - vm_image_base
     - vm_images
     - ardupilot
+    - logging
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Checkout submodules
       run: |
         git submodule update --init components/autopilot/ardupilot
+        (cd components/autopilot/ardupilot && git submodule update --init modules/mavlink)
         git submodule update --init src/pkvm_setup/libgpiod
         git submodule update --init src/pkvm_setup/linux-pkvm
         git submodule update --init src/pkvm_setup/qemu
@@ -651,6 +654,12 @@ jobs:
       with:
         key: ${{ needs.mps-build.outputs.CACHE_KEY }}
         path: packages/${{ needs.mps-build.outputs.CACHE_KEY }}.tar.gz
+        fail-on-cache-miss: true
+    - name: "Cache restore: trusted-boot-build"
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ needs.trusted-boot-build.outputs.CACHE_KEY }}
+        path: packages/${{ needs.trusted-boot-build.outputs.CACHE_KEY }}.tar.gz
         fail-on-cache-miss: true
     - name: "Cache restore: vm_runner"
       uses: actions/cache/restore@v4
@@ -699,6 +708,12 @@ jobs:
       with:
         key: ${{ needs.ardupilot.outputs.CACHE_KEY }}
         path: packages/${{ needs.ardupilot.outputs.CACHE_KEY }}.tar.gz
+        fail-on-cache-miss: true
+    - name: "Cache restore: logging"
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ needs.logging.outputs.CACHE_KEY }}
+        path: packages/${{ needs.logging.outputs.CACHE_KEY }}.tar.gz
         fail-on-cache-miss: true
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -626,9 +626,51 @@ jobs:
 
   opensut-base:
     runs-on: ubuntu-latest
+    needs:
+    - mps-build
+    - vm_images
+    - vm_runner
+    - vhost_device
+    - ardupilot
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+    - name: Cache results
+      id: cache
+      uses: actions/cache@v4
+      with:
+        key: ${{ env.CACHE_KEY }}
+        path: packages/${{ env.CACHE_KEY }}.tar.gz
+    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      name: "Cache restore: vm_runner"
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ needs.vm_runner.outputs.CACHE_KEY }}
+        path: packages/${{ needs.vm_runner.outputs.CACHE_KEY }}.tar.gz
+    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      name: "Cache restore: vhost_device"
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ needs.vhost_device.outputs.CACHE_KEY }}
+        path: packages/${{ needs.vhost_device.outputs.CACHE_KEY }}.tar.gz
+    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      name: "Cache restore: pkvm"
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ needs.pkvm.outputs.CACHE_KEY }}
+        path: packages/${{ needs.pkvm.outputs.CACHE_KEY }}.tar.gz
+    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      name: "Cache restore: qemu"
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ needs.qemu.outputs.CACHE_KEY }}
+        path: packages/${{ needs.qemu.outputs.CACHE_KEY }}.tar.gz
+    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      name: "Cache restore: vm_image_base"
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ needs.vm_image_base.outputs.CACHE_KEY }}
+        path: packages/${{ needs.vm_image_base.outputs.CACHE_KEY }}.tar.gz
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -454,42 +454,42 @@ jobs:
       run: RUST_LOG=trace MPS_DEBUG=1 python3 src/vm_runner/tests/mps/run_tests.py
 
   ardupilot:
-      runs-on: ubuntu-22.04
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
-        - name: Checkout submodules
-          run: |
-              git config --global url."https://galoisactions:${{ secrets.VERSE_VHOST_DEVICE_ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
-              git submodule update --init components/autopilot/ardupilot
-        - name: Hash inputs
-          id: hash
-          run: |
-              cache_key="$(bash src/pkvm_setup/package.sh cache_key ardupilot)"
-              echo "Cache key: $cache_key"
-              echo "CACHE_KEY=$cache_key" >>$GITHUB_OUTPUT
-              echo "CACHE_KEY=$cache_key" >>$GITHUB_ENV
-        - name: Cache results
-          id: cache
-          uses: actions/cache@v4
-          with:
-              key: ${{ env.CACHE_KEY }}
-              path: packages/${{ env.CACHE_KEY }}.tar.gz
-        - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-          name: Install dependencies
-          run: |
-            sudo apt-get update
-            BUILD_ONLY=1 bash components/autopilot/ardupilot_install_deps.sh
-        - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-          name: Fetch additional submodules for build
-          run: |
-            bash components/autopilot/ardupilot_init_submodules.sh
-        - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-          name: Build ArduPilot
-          run: |
-              bash src/pkvm_setup/package.sh full_build ardupilot
-      outputs:
-          CACHE_KEY: ${{ steps.hash.outputs.CACHE_KEY }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Checkout submodules
+        run: |
+            git config --global url."https://galoisactions:${{ secrets.VERSE_VHOST_DEVICE_ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
+            git submodule update --init components/autopilot/ardupilot
+      - name: Hash inputs
+        id: hash
+        run: |
+            cache_key="$(bash src/pkvm_setup/package.sh cache_key ardupilot)"
+            echo "Cache key: $cache_key"
+            echo "CACHE_KEY=$cache_key" >>$GITHUB_OUTPUT
+            echo "CACHE_KEY=$cache_key" >>$GITHUB_ENV
+      - name: Cache results
+        id: cache
+        uses: actions/cache@v4
+        with:
+            key: ${{ env.CACHE_KEY }}
+            path: packages/${{ env.CACHE_KEY }}.tar.gz
+      - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        name: Install dependencies
+        run: |
+          sudo apt-get update
+          BUILD_ONLY=1 bash components/autopilot/ardupilot_install_deps.sh
+      - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        name: Fetch additional submodules for build
+        run: |
+          bash components/autopilot/ardupilot_init_submodules.sh
+      - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        name: Build ArduPilot
+        run: |
+            bash src/pkvm_setup/package.sh full_build ardupilot
+    outputs:
+        CACHE_KEY: ${{ steps.hash.outputs.CACHE_KEY }}
 
   logging:
       runs-on: ubuntu-22.04
@@ -534,89 +534,89 @@ jobs:
           CACHE_KEY: ${{ steps.hash.outputs.CACHE_KEY }}
 
   jsbsim_proxy:
-      runs-on: ubuntu-22.04
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
-        # jsbsim_proxy is trivial to build, so we don't bother packaging or
-        # caching it.
-        - name: Install dependencies
-          run: |
-            sudo apt-get update
-            sudo apt install build-essential
-        - name: Build jsbsim_proxy
-          run: |
-              cd src/jsbsim_proxy
-              make
-              [ -f jsbsim_proxy ]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # jsbsim_proxy is trivial to build, so we don't bother packaging or
+      # caching it.
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt install build-essential
+      - name: Build jsbsim_proxy
+        run: |
+          cd src/jsbsim_proxy
+          make
+          [ -f jsbsim_proxy ]
 
   mkm:
-      runs-on: ubuntu-22.04
-      needs: trusted-boot-build
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
-        # mkm is trivial to build, so we don't bother packaging or caching it.
-        - name: Install dependencies
-          run: |
-            sudo apt-get update
-            sudo apt-get install -y build-essential
-            sudo apt-get install -y {gcc,g++}-aarch64-linux-gnu
-        - name: Build mkm
-          run: |
-              cd components/mission_key_management
-              make
-              [ -f mkm ]
-              make TARGET=aarch64
-              [ -f mkm.aarch64 ]
-        # Some test cases require the `trusted_boot` binary for generating
-        # attestations.
-        - name: Download trusted_boot binary
-          uses: actions/download-artifact@v4
-          with:
-            name: trusted-boot-binaries
-        - name: Move trusted_boot binary into place
-          run: |
-              chmod -v +x trusted_boot
-              mv -v trusted_boot components/platform_crypto/shave_trusted_boot/
-        - name: Run tests
-          run: |
-              cd components/mission_key_management
-              python3 run_tests.py
+    runs-on: ubuntu-22.04
+    needs: trusted-boot-build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # mkm is trivial to build, so we don't bother packaging or caching it.
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+          sudo apt-get install -y {gcc,g++}-aarch64-linux-gnu
+      - name: Build mkm
+        run: |
+          cd components/mission_key_management
+          make
+          [ -f mkm ]
+          make TARGET=aarch64
+          [ -f mkm.aarch64 ]
+      # Some test cases require the `trusted_boot` binary for generating
+      # attestations.
+      - name: Download trusted_boot binary
+        uses: actions/download-artifact@v4
+        with:
+          name: trusted-boot-binaries
+      - name: Move trusted_boot binary into place
+        run: |
+          chmod -v +x trusted_boot
+          mv -v trusted_boot components/platform_crypto/shave_trusted_boot/
+      - name: Run tests
+        run: |
+          cd components/mission_key_management
+          python3 run_tests.py
 
   mkm_client:
-      runs-on: ubuntu-22.04
-      needs: trusted-boot-build
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
-        # mkm is trivial to build, so we don't bother packaging or caching it.
-        - name: Install dependencies
-          run: |
-            sudo apt-get update
-            sudo apt-get install -y build-essential
-            sudo apt-get install -y {gcc,g++}-aarch64-linux-gnu
-        - name: Build mkm
-          run: |
-              cd components/mission_key_management
-              make
-              [ -f mkm ]
-        - name: Build mkm_client
-          run: |
-              cd components/mkm_client
-              make
-              [ -f mkm_client ]
-              make TARGET=aarch64
-              [ -f mkm_client.aarch64 ]
-        - name: Download trusted_boot binary
-          uses: actions/download-artifact@v4
-          with:
-            name: trusted-boot-binaries
-        - name: Move trusted_boot binary into place
-          run: |
-              chmod -v +x trusted_boot
-              mv -v trusted_boot components/platform_crypto/shave_trusted_boot/
-        - name: Run tests
-          run: |
-              cd components/mkm_client
-              bash run_tests.sh
+    runs-on: ubuntu-22.04
+    needs: trusted-boot-build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # mkm is trivial to build, so we don't bother packaging or caching it.
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+          sudo apt-get install -y {gcc,g++}-aarch64-linux-gnu
+      - name: Build mkm
+        run: |
+          cd components/mission_key_management
+          make
+          [ -f mkm ]
+      - name: Build mkm_client
+        run: |
+          cd components/mkm_client
+          make
+          [ -f mkm_client ]
+          make TARGET=aarch64
+          [ -f mkm_client.aarch64 ]
+      - name: Download trusted_boot binary
+        uses: actions/download-artifact@v4
+        with:
+          name: trusted-boot-binaries
+      - name: Move trusted_boot binary into place
+        run: |
+          chmod -v +x trusted_boot
+          mv -v trusted_boot components/platform_crypto/shave_trusted_boot/
+      - name: Run tests
+        run: |
+          cd components/mkm_client
+          bash run_tests.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -628,49 +628,78 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - mps-build
-    - vm_images
     - vm_runner
+    - libgpiod
     - vhost_device
+    - pkvm
+    - qemu
+    - vm_image_base
+    - vm_images
     - ardupilot
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-    - name: Cache results
-      id: cache
-      uses: actions/cache@v4
+    - name: Checkout submodules
+      run: |
+        git submodule update --init components/autopilot/ardupilot
+        git submodule update --init src/pkvm_setup/libgpiod
+        git submodule update --init src/pkvm_setup/linux-pkvm
+        git submodule update --init src/pkvm_setup/qemu
+        git submodule update --init src/pkvm_setup/vhost-device
+    - name: "Cache restore: mps-build"
+      uses: actions/cache/restore@v4
       with:
-        key: ${{ env.CACHE_KEY }}
-        path: packages/${{ env.CACHE_KEY }}.tar.gz
-    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-      name: "Cache restore: vm_runner"
+        key: ${{ needs.mps-build.outputs.CACHE_KEY }}
+        path: packages/${{ needs.mps-build.outputs.CACHE_KEY }}.tar.gz
+        fail-on-cache-miss: true
+    - name: "Cache restore: vm_runner"
       uses: actions/cache/restore@v4
       with:
         key: ${{ needs.vm_runner.outputs.CACHE_KEY }}
         path: packages/${{ needs.vm_runner.outputs.CACHE_KEY }}.tar.gz
-    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-      name: "Cache restore: vhost_device"
+        fail-on-cache-miss: true
+    - name: "Cache restore: libgpiod"
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ needs.libgpiod.outputs.CACHE_KEY }}
+        path: packages/${{ needs.libgpiod.outputs.CACHE_KEY }}.tar.gz
+        fail-on-cache-miss: true
+    - name: "Cache restore: vhost_device"
       uses: actions/cache/restore@v4
       with:
         key: ${{ needs.vhost_device.outputs.CACHE_KEY }}
         path: packages/${{ needs.vhost_device.outputs.CACHE_KEY }}.tar.gz
-    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-      name: "Cache restore: pkvm"
+        fail-on-cache-miss: true
+    - name: "Cache restore: pkvm"
       uses: actions/cache/restore@v4
       with:
         key: ${{ needs.pkvm.outputs.CACHE_KEY }}
         path: packages/${{ needs.pkvm.outputs.CACHE_KEY }}.tar.gz
-    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-      name: "Cache restore: qemu"
+        fail-on-cache-miss: true
+    - name: "Cache restore: qemu"
       uses: actions/cache/restore@v4
       with:
         key: ${{ needs.qemu.outputs.CACHE_KEY }}
         path: packages/${{ needs.qemu.outputs.CACHE_KEY }}.tar.gz
-    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-      name: "Cache restore: vm_image_base"
+        fail-on-cache-miss: true
+    - name: "Cache restore: vm_image_base"
       uses: actions/cache/restore@v4
       with:
         key: ${{ needs.vm_image_base.outputs.CACHE_KEY }}
         path: packages/${{ needs.vm_image_base.outputs.CACHE_KEY }}.tar.gz
+        fail-on-cache-miss: true
+    - name: "Cache restore: vm_images"
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ needs.vm_images.outputs.CACHE_KEY }}
+        path: packages/${{ needs.vm_images.outputs.CACHE_KEY }}.tar.gz
+        fail-on-cache-miss: true
+    - name: "Cache restore: ardupilot"
+      uses: actions/cache/restore@v4
+      with:
+        key: ${{ needs.ardupilot.outputs.CACHE_KEY }}
+        path: packages/${{ needs.ardupilot.outputs.CACHE_KEY }}.tar.gz
+        fail-on-cache-miss: true
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:
@@ -683,15 +712,3 @@ jobs:
         docker build . --file Dockerfile --tag ${{env.OPENSUT_BASE_IMAGE_ID}}
     - name: Push the Docker image
       run: docker push ${{env.OPENSUT_BASE_IMAGE_ID}}
-    # - name: Set up QEMU
-    #   uses: docker/setup-qemu-action@v3
-    # - name: Set up Docker Buildx
-    #   uses: docker/setup-buildx-action@v3
-    # - name: Build and push
-    #   uses: docker/build-push-action@v6
-    #   with:
-    #     platforms: linux/amd64
-    #     tags: ${{env.OPENSUT_BASE_IMAGE_ID}}
-    #     file: Dockerfile
-    #     github-token: ${{ secrets.VERSE_OPENSUT_ACCESS_TOKEN }}
-    #     push: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -645,6 +645,7 @@ jobs:
       run: |
         git submodule update --init components/autopilot/ardupilot
         (cd components/autopilot/ardupilot && git submodule update --init modules/mavlink)
+        git submodule update --init components/autopilot/jsbsim
         git submodule update --init src/pkvm_setup/libgpiod
         git submodule update --init src/pkvm_setup/linux-pkvm
         git submodule update --init src/pkvm_setup/qemu

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -644,5 +644,6 @@ jobs:
       with:
         platforms: linux/amd64
         tags: ${{env.OPENSUT_BASE_IMAGE_ID}}
-        file: Dockerfile.ubuntu
+        file: Dockerfile
         github-token: ${{ secrets.VERSE_OPENSUT_ACCESS_TOKEN }}
+        push: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   #workflow_dispatch:
 
+env:
+  OPENSUT_BASE_IMAGE_ID: ghcr.io/galoisinc/verse-opensut/opensut-base:latest
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   mps-build:
@@ -620,3 +623,26 @@ jobs:
         run: |
           cd components/mkm_client
           bash run_tests.sh
+
+  opensut-base:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.VERSE_OPENSUT_ACCESS_TOKEN }}
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        platforms: linux/amd64
+        tags: ${{env.OPENSUT_BASE_IMAGE_ID}}
+        file: Dockerfile.ubuntu
+        github-token: ${{ secrets.VERSE_OPENSUT_ACCESS_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -677,15 +677,21 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.VERSE_OPENSUT_ACCESS_TOKEN }}
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    - name: Build and push
-      uses: docker/build-push-action@v6
-      with:
-        platforms: linux/amd64
-        tags: ${{env.OPENSUT_BASE_IMAGE_ID}}
-        file: Dockerfile
-        github-token: ${{ secrets.VERSE_OPENSUT_ACCESS_TOKEN }}
-        push: true
+    - name: Build the Docker image
+      run: |
+        echo "Building ${{env.OPENSUT_BASE_IMAGE_ID}}"
+        docker build . --file Dockerfile --tag ${{env.OPENSUT_BASE_IMAGE_ID}}
+    - name: Push the Docker image
+      run: docker push ${{env.OPENSUT_BASE_IMAGE_ID}}
+    # - name: Set up QEMU
+    #   uses: docker/setup-qemu-action@v3
+    # - name: Set up Docker Buildx
+    #   uses: docker/setup-buildx-action@v3
+    # - name: Build and push
+    #   uses: docker/build-push-action@v6
+    #   with:
+    #     platforms: linux/amd64
+    #     tags: ${{env.OPENSUT_BASE_IMAGE_ID}}
+    #     file: Dockerfile
+    #     github-token: ${{ secrets.VERSE_OPENSUT_ACCESS_TOKEN }}
+    #     push: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,13 +10,13 @@
 	shallow = true
 [submodule "components/autopilot/ardupilot"]
 	path = components/autopilot/ardupilot
-	url = git@github.com:GaloisInc/verse-ardupilot.git
+	url = https://github.com/GaloisInc/verse-ardupilot.git
 [submodule "components/message_bus/czmq"]
 	path = components/message_bus/czmq
 	url = https://github.com/zeromq/czmq.git
 [submodule "src/pkvm_setup/vhost-device"]
 	path = src/pkvm_setup/vhost-device
-	url = git@github.com:GaloisInc/verse-vhost-device.git
+	url = https://github.com/GaloisInc/verse-vhost-device.git
 [submodule "src/pkvm_setup/libgpiod"]
 	path = src/pkvm_setup/libgpiod
 	url = https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git
@@ -25,7 +25,7 @@
 	url = https://github.com/rems-project/cerberus.git
 [submodule "src/pkvm_setup/qemu"]
 	path = src/pkvm_setup/qemu
-	url = git@github.com:GaloisInc/verse-debian-qemu.git
+	url = https://github.com/GaloisInc/verse-debian-qemu.git
 [submodule "components/autopilot/jsbsim"]
 	path = components/autopilot/jsbsim
 	url = https://github.com/JSBSim-Team/jsbsim

--- a/Dockerfile
+++ b/Dockerfile
@@ -137,4 +137,5 @@ WORKDIR /opt/OpenSUT
 RUN bash src/vm_runner/tests/opensut-dev/build_img.sh
 RUN truncate -s 64M src/vm_runner/logging_data.img
 
-RUN apt-get install -y tmux
+# Useful tools for trying out the OpenSUT
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tmux xxd cryptsetup

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN apt-get clean \
 RUN apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
   && apt-get install -y verilator
 
+# trusted-boot-build
+RUN apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
 # mps-test
 RUN apt-get install -y python3-pip
 
@@ -64,8 +67,19 @@ RUN apt-get install -y qemu-system-arm
 # ardupilot
 # The deps are handled by the install scripts below
 
+# logging
+RUN apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
 # jsbsim_proxy
 RUN apt-get install -y build-essential
+
+# mkm
+RUN apt-get install -y build-essential \
+  && apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+# mkm_client
+RUN apt-get install -y build-essential \
+  && apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
 
 # Install rustup & pin to 1.74

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,10 @@ RUN make TARGET=aarch64
 WORKDIR /opt/OpenSUT/components/autopilot
 RUN bash jsbsim_build.sh
 
+# Adjust vm_runner configs for use in Docker
+WORKDIR /opt/OpenSUT/src/vm_runner
+RUN sed -i -e '/##DOCKER/s/^#//' -e '/##NOT-DOCKER/s/^/#/' tests/*/*.toml
+
 WORKDIR /opt/OpenSUT
 RUN bash src/vm_runner/tests/opensut-dev/build_img.sh
 RUN truncate -s 64M src/vm_runner/logging_data.img

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,9 @@ RUN apt-get install -y build-essential \
 RUN apt-get install -y build-essential \
   && apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
+# jsbsim
+RUN apt-get install -y build-essential cmake
+
 
 # Install rustup & pin to 1.74
 WORKDIR /tmp
@@ -121,3 +124,7 @@ RUN make TARGET=aarch64
 WORKDIR /opt/OpenSUT/components/mkm_client
 RUN make
 RUN make TARGET=aarch64
+
+# JSBSim
+WORKDIR /opt/OpenSUT/components/autopilot
+RUN bash jsbsim_build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,57 +98,26 @@ RUN apt-get install -y qemu-system-arm
 COPY . /opt/OpenSUT
 WORKDIR /opt/OpenSUT
 
+
 # FIXME: when running `docker build` locally, there may be extra package
 # versions in the `packages` directory, which will overwrite each other
 # arbitrarily here
 RUN for f in packages/*; do tar -xvf "$f"; done
 RUN rm -v packages/*
 
-## BUILD ##
 
-# ardupilot
-
+# Build components that aren't managed by package.sh
 
 # jsbsim_proxy
-#RUN cd src/jsbsim_proxy \
-#  && make \
-#  && [ -f jsbsim_proxy ]
-## BUILD ##
+WORKDIR /opt/OpenSUT/src/jsbsim_proxy
+RUN make
 
-# # ardupilot
-# RUN git submodule update --init components/autopilot/ardupilot
+# mkm
+WORKDIR /opt/OpenSUT/components/mission_key_management
+RUN make
+RUN make TARGET=aarch64
 
-# # Install dependencies
-# RUN apt-get update \
-#   && echo "Install general dependencies" \
-#   && apt-get install -y curl git pkg-config m4 \
-#   && echo "Install jsbsim proxy and libgpiod / vhost-device dependencies" \
-#   && apt-get install -y build-essential autoconf automake autoconf-archive libtool \
-#   && echo "Install trusted boot dependencies" \
-#   && apt-get install -y  gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
-#   && echo "Install missing protection system (MPS) dependencies" \
-#   && apt-get install -y verilator python3-pip clang
-
-
-
-# # Prepare deb-src
-# RUN touch /etc/apt/sources.list \
-#   && echo "deb-src http://deb.debian.org/debian bookworm main contrib non-free" > /etc/apt/sources.list \
-#   && apt-get update
-# # Other sources:
-# # deb-src http://deb.debian.org/debian bookworm-updates main contrib non-free
-# # deb-src http://deb.debian.org/debian-security bookworm-security main contrib non-free
-
-# # Build dependencies for linux-pkvm / linux-pkvm-verif kernel
-# RUN apt build-dep -y linux
-
-# # The following deps are needed to build the VM images
-# # Disk image and qemu dependencies
-# # bash src/pkvm_setup/package.sh full_build {qemu,pkvm,vm_image_base}
-# RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
-#   qemu-system-arm qemu-utils \
-#   debian-installer-12-netboot-arm64 \
-#   cpio
-
-WORKDIR /work
-RUN rm -rf /tmp/*
+# mkm_client
+WORKDIR /opt/OpenSUT/components/mkm_client
+RUN make
+RUN make TARGET=aarch64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1.7-labs
 
 # Top Level VERSE OpenSUT Dockerfile
-FROM --platform=linux/amd64 ubuntu:22.04
+# NOTE: migrating to a newer OS to support MPS test job
+FROM --platform=linux/amd64 ubuntu:24.04
 
 # Labels added as described in
 # https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
@@ -15,15 +16,84 @@ RUN apt-get clean \
   && apt-get upgrade -y \
   && apt-get install -y curl git
 
-COPY --exclude=.git/ . /opt/OpenSUT
-WORKDIR /opt/OpenSUT
+# Install system packages for all stages
+# This step is *before* we add the OpenSUT repo
+# to maximize caching
+#
+# MPS
+RUN apt-get update \
+  && apt-get install -y verilator \
+  && apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
+  && apt-get install -y python3-pip
+
+# Trusted boot
+# (identical to the previous stage)
+#RUN apt-get update \
+#  && apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+# VM Runner
+# (identical to the previous stage)
+#RUN apt-get update \
+#  && apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+# Install rustup & pin to 1.74
+WORKDIR /tmp
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup.rs \
+  && sh ./rustup.rs -y \
+  && . "$HOME/.cargo/env"
+ENV PATH="/root/.cargo/bin:$PATH"
+RUN rustup toolchain install 1.74
+RUN rustup default 1.74-x86_64-unknown-linux-gnu
+RUN rustup target add aarch64-unknown-linux-gnu
+ENV RUSTUP_TOOLCHAIN=1.74
+
+## DEPENDENCY INSTALL ##
+# libgpiod
+RUN apt-get update \
+  && apt-get install -y \
+  build-essential autoconf automake autoconf-archive \
+  gcc-aarch64-linux-gnu
+
+# vhost_device
+# (identical to the previous stage)
+# RUN apt-get update \
+#   && apt-get install -y \
+#   build-essential autoconf automake autoconf-archive \
+
+# pkvm
+# (will be downloaded from artifactory)
+
+# qemu
+# (will be downloaded from artifactory)
+
+# vm_image_base
+# (will be downloaded from artifactory)
+
+# vm_images
+RUN apt-get update \
+  && apt-get install -y qemu-system-arm qemu-utils
+
+# mps-test-vm
+RUN apt-get update \
+  && apt-get install -y qemu-system-arm
+
+# ardupilot
+# The deps are handled by the install scripts below
 
 # jsbsim_proxy
-RUN apt-get update \
-  && apt-get install -y build-essential
+# (identical to the previous stage)
+# RUN apt-get update \
+#   && apt-get install -y build-essential
+## DEPENDENCY INSTALL ##
+
+COPY . /opt/OpenSUT
+WORKDIR /opt/OpenSUT
+
+## BUILD ##
+# jsbsim_proxy
 RUN cd src/jsbsim_proxy \
   && make \
   && [ -f jsbsim_proxy ]
+## BUILD ##
 
 # # ardupilot
 # RUN git submodule update --init components/autopilot/ardupilot
@@ -39,15 +109,6 @@ RUN cd src/jsbsim_proxy \
 #   && echo "Install missing protection system (MPS) dependencies" \
 #   && apt-get install -y verilator python3-pip clang
 
-# # Install rustup & pin to 1.74
-# WORKDIR /tmp
-# RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup.rs \
-#   && sh ./rustup.rs -y \
-#   && . "$HOME/.cargo/env"
-# ENV PATH="/root/.cargo/bin:$PATH"
-# RUN rustup toolchain install 1.74
-# RUN rustup default 1.74-x86_64-unknown-linux-gnu
-# RUN rustup target add aarch64-unknown-linux-gnu
 
 
 # # Prepare deb-src

--- a/Dockerfile
+++ b/Dockerfile
@@ -128,3 +128,9 @@ RUN make TARGET=aarch64
 # JSBSim
 WORKDIR /opt/OpenSUT/components/autopilot
 RUN bash jsbsim_build.sh
+
+WORKDIR /opt/OpenSUT
+RUN bash src/vm_runner/tests/opensut-dev/build_img.sh
+RUN truncate -s 64M src/vm_runner/logging_data.img
+
+RUN apt-get install -y tmux

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,10 @@ COPY . /opt/OpenSUT
 WORKDIR /opt/OpenSUT
 
 ## BUILD ##
+
+# ardupilot
+
+
 # jsbsim_proxy
 RUN cd src/jsbsim_proxy \
   && make \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get clean \
   && apt-get upgrade -y \
   && apt-get install -y curl git
 
-COPY . /opt/OpenSUT
+COPY --exclude=.git/ . /opt/OpenSUT
 WORKDIR /opt/OpenSUT
 
 # jsbsim_proxy

--- a/docs/OPENSUT_DOCKER.md
+++ b/docs/OPENSUT_DOCKER.md
@@ -1,5 +1,16 @@
 # Running the OpenSUT under Docker
 
+## Install dependencies
+
+Most dependencies are preinstalled within the OpenSUT Docker image.  However,
+the graphical MAVProxy tool, which is required to start the autopilot mission,
+must be run on the host machine.  To install MAVProxy and other Ardupilot
+dependencies:
+
+```sh
+bash components/autopilot/ardupilot_install_deps.sh
+```
+
 ## Fetch or build the Docker image
 
 To fetch the Docker image:
@@ -89,9 +100,6 @@ usually ready:
 [   37.865934] trusted_boot[276]: connection closed (will retry)
 [   39.869003] trusted_boot[276]: connection closed (will retry)
 ```
-
-TODO: Instructions for installing MAVProxy dependencies (maybe just need to run
-`components/autopilot/ardupilot_install_deps.sh`?)
 
 Now, in a separate terminal on the base system, run MAVProxy:
 

--- a/docs/OPENSUT_DOCKER.md
+++ b/docs/OPENSUT_DOCKER.md
@@ -5,7 +5,7 @@
 To fetch the Docker image:
 
 ```sh
-# TODO
+docker pull ghcr.io/galoisinc/verse-opensut/opensut-base:latest
 ```
 
 Building the Docker image from scratch first requires building all of the
@@ -42,13 +42,13 @@ bash src/pkvm_setup/package.sh full_build mkm_client
 bash src/pkvm_setup/package.sh full_build vm_images
 
 # Build Docker image
-docker build . -t opensut-base
+docker build . -t ghcr.io/galoisinc/verse-opensut/opensut-base:latest
 ```
 
 ## Run the container
 
 ```sh
-docker run --privileged --rm -it -p 5760:5760 opensut-base:latest
+docker run --privileged --rm -it -p 5760:5760 ghcr.io/galoisinc/verse-opensut/opensut-base:latest
 ```
 
 Forwarding port 5760 into the container allows MAVProxy on the base machine to
@@ -58,8 +58,8 @@ container -> OpenSUT host VM -> OpenSUT guest VMs.  Ardupilot runs on one of
 the OpenSUT guest VMs.)
 
 The `--privileged` flag is necessary to allow opening the encrypted filesystem
-where logs are stored after the mission is complete ([see the instructions
-below](#read-the-logs)).
+that contains telemetry logs after the mission is complete ([see the
+instructions below](#read-the-logs)).
 
 ## Run the mission
 
@@ -148,3 +148,11 @@ less /mnt/log-*.txt
 There should be several entries recorded during startup all with roughly the
 same latitude, longitude, and altitude, followed by entries where these fields
 vary as the autopilot flies the mission.
+
+Afterward, close the encrypted filesystem (otherwise it will remain open on the
+host after the container has terminated):
+
+```sh
+umount /mnt
+cryptsetup luksClose logging_data
+```

--- a/docs/OPENSUT_DOCKER.md
+++ b/docs/OPENSUT_DOCKER.md
@@ -1,0 +1,150 @@
+# Running the OpenSUT under Docker
+
+## Fetch or build the Docker image
+
+To fetch the Docker image:
+
+```sh
+# TODO
+```
+
+Building the Docker image from scratch first requires building all of the
+OpenSUT components.
+
+```sh
+# Install system dependencies
+sudo apt-get install -y \
+    build-essential autoconf automake autoconf-archive cmake \
+    gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
+    verilator \
+    python3-pip \
+    qemu-system-arm qemu-utils
+
+# Dockerfile expects `packages/` directory to have no extraneous files.
+rm -f packages/*
+
+# Build packages
+
+# Use `download foo -u USERNAME` instead of `full_build foo` if you have an
+# Artifactory API key
+bash src/pkvm_setup/package.sh full_build pkvm
+bash src/pkvm_setup/package.sh full_build qemu
+bash src/pkvm_setup/package.sh full_build vm_image_base
+
+bash src/pkvm_setup/package.sh full_build trusted_boot
+bash src/pkvm_setup/package.sh full_build libgpiod
+bash src/pkvm_setup/package.sh full_build vm_runner
+bash src/pkvm_setup/package.sh full_build ardupilot
+bash src/pkvm_setup/package.sh full_build logging
+bash src/pkvm_setup/package.sh full_build vhost_device
+bash src/pkvm_setup/package.sh full_build mkm
+bash src/pkvm_setup/package.sh full_build mkm_client
+bash src/pkvm_setup/package.sh full_build vm_images
+
+# Build Docker image
+docker build . -t opensut-base
+```
+
+## Run the container
+
+```sh
+docker run --privileged --rm -it -p 5760:5760 opensut-base:latest
+```
+
+Forwarding port 5760 into the container allows MAVProxy on the base machine to
+connect to Ardupilot inside the container, which allows the user to start the
+mission.  (Specifically, there are several levels of nesting: base machine ->
+container -> OpenSUT host VM -> OpenSUT guest VMs.  Ardupilot runs on one of
+the OpenSUT guest VMs.)
+
+The `--privileged` flag is necessary to allow opening the encrypted filesystem
+where logs are stored after the mission is complete ([see the instructions
+below](#read-the-logs)).
+
+## Run the mission
+
+Within the container, run `tmux`.
+
+In the first tmux window, start `jsbsim_proxy`:
+
+```sh
+bash components/autopilot/run_jsbsim.sh
+```
+
+Press `^B` `c` to create a second tmux window.  In the second window, start the
+OpenSUT:
+
+```sh
+cd src/vm_runner
+# FIXME: Switch to base_nested.toml to run the full nested OpenSUT setup
+target/release/opensut_vm_runner tests/opensut-dev/base_single.toml
+```
+
+Wait for the various OpenSUT VMs to boot.  Usually the logging component is the
+last to start up; once it starts printing messages like these, the system is
+usually ready:
+
+```
+[   35.861091] trusted_boot[276]: connection closed (will retry)
+[   37.865934] trusted_boot[276]: connection closed (will retry)
+[   39.869003] trusted_boot[276]: connection closed (will retry)
+```
+
+TODO: Instructions for installing MAVProxy dependencies (maybe just need to run
+`components/autopilot/ardupilot_install_deps.sh`?)
+
+Now, in a separate terminal on the base system, run MAVProxy:
+
+```sh
+bash components/autopilot/run_mavproxy.sh
+```
+
+MAVProxy should start up and connect to the autopilot component.  As described
+in the [autopilot README](../components/autopilot/README.md), load the example
+mission, wait for the `PRE` (pre-arm) indicator to turn green, and start the
+mission:
+
+```
+wp load components/autopilot/ardupilot/Tools/autotest/Generic_Missions/CMAC-circuit.txt
+mode auto
+# Wait until `PRE` is green
+arm throttle
+```
+
+In the MAVProxy map window, you should see the plane take off and fly toward
+the waypoints.
+
+The plane will continue flying until manually stopped.  To stop it:
+1. Press `^C` in the terminal where you started MAVProxy.  This should close
+   both MAVProxy windows.
+2. In the container, switch to tmux window 0 by pressing `^B` `0`, then press
+   `^C` to stop JSBSim.
+3. Switch to tmux window 1 by pressing `^B` `1`.  Press `^B` `x` to close the
+   window and stop the OpenSUT VMs, then press `y` to confirm.
+
+## Read the logs
+
+First, get the encryption key from the MKM config file:
+
+```sh
+cd src/vm_runner
+key=$(grep key0 tests/opensut-dev/mkm_config.ini | cut -d\  -f3)
+```
+
+Next, open and mount the encrypted filesystem:
+
+```sh
+echo "$key" | xxd -r -p | cryptsetup luksOpen --key-file=- logging_data.img logging_data
+mount /dev/mapper/logging_data /mnt
+```
+
+Finally, read the logs:
+
+```sh
+ls /mnt
+less /mnt/log-*.txt
+```
+
+There should be several entries recorded during startup all with roughly the
+same latitude, longitude, and altitude, followed by entries where these fields
+vary as the autopilot flies the mission.

--- a/src/pkvm_setup/package.sh
+++ b/src/pkvm_setup/package.sh
@@ -52,6 +52,7 @@ vm_runner_get_input_hashes() {
 vm_runner_build() {
     (
         cd src/vm_runner
+        cargo build --release
         cargo build --release --target aarch64-unknown-linux-gnu
         bash build_deb.sh
     )
@@ -62,6 +63,7 @@ vm_runner_list_outputs() {
     deb="$(sole src/vm_runner/verse-opensut-boot_*_arm64.deb)"
     echo "$deb"
     echo "${deb%.deb}.opensut_boot.measure.txt"
+    echo src/vm_runner/target/release/opensut_vm_runner
 }
 
 

--- a/src/vm_runner/src/config.rs
+++ b/src/vm_runner/src/config.rs
@@ -173,6 +173,12 @@ pub struct UserNet {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PortForward {
+    /// IP address of the interface to bind to on the host machine.
+    ///
+    /// This defaults to 127.0.0.1.  This can be set to 0.0.0.0 if other machines on the host's
+    /// network should be able to access the forwarded port.
+    #[serde(default = "const_string_127_0_0_1")]
+    pub outer_host: String,
     pub outer_port: u16,
     /// IP address to forward to within the VM network.
     ///
@@ -191,6 +197,10 @@ pub struct PortForward {
 pub enum PortForwardProtocol {
     Tcp,
     Udp,
+}
+
+fn const_string_127_0_0_1() -> String {
+    "127.0.0.1".into()
 }
 
 fn const_port_forward_protocol_tcp() -> PortForwardProtocol {

--- a/src/vm_runner/src/lib.rs
+++ b/src/vm_runner/src/lib.rs
@@ -303,8 +303,8 @@ fn build_vm_command(paths: &Paths, vm: &config::VmProcess, cmds: &mut Commands) 
                         PortForwardProtocol::Tcp => "tcp",
                         PortForwardProtocol::Udp => "udp",
                     };
-                    write!(netdev_str, ",hostfwd={proto}:127.0.0.1:{}-{}:{}",
-                        pf.outer_port, pf.inner_host, pf.inner_port).unwrap();
+                    write!(netdev_str, ",hostfwd={proto}:{}:{}-{}:{}",
+                        pf.outer_host, pf.outer_port, pf.inner_host, pf.inner_port).unwrap();
                 }
                 args!("-device" (format!("virtio-net-pci,netdev=net_{key}")));
                 args!("-netdev" netdev_str);

--- a/src/vm_runner/tests/opensut-dev/base_single.toml
+++ b/src/vm_runner/tests/opensut-dev/base_single.toml
@@ -68,6 +68,8 @@ inner_host = "10.0.2.122"
 inner_port = 22
 
 [process.net.default.port_forward.ardupilot_serial0]
+#outer_host = "0.0.0.0"     ##DOCKER
+outer_host = "127.0.0.1"    ##NOT-DOCKER
 outer_port = 5760
 inner_host = "10.0.2.122"
 inner_port = 5760

--- a/src/vm_runner/tests/opensut-dev/base_single.toml
+++ b/src/vm_runner/tests/opensut-dev/base_single.toml
@@ -36,9 +36,9 @@ path = "../../serial.socket"
 
 # FIXME: under Docker with ubuntu 24.04 base image, QEMU gets SIGBUS when
 # vhost-user-gpio is enabled
-#[process.gpio.gpiochip1]
-#mode = "external"
-#path = "../../gpiochip1.socket"
+[process.gpio.gpiochip1]            ##NOT-DOCKER
+mode = "external"                   ##NOT-DOCKER
+path = "../../gpiochip1.socket"     ##NOT-DOCKER
 
 
 # Ardupilot

--- a/src/vm_runner/tests/opensut-dev/base_single.toml
+++ b/src/vm_runner/tests/opensut-dev/base_single.toml
@@ -34,9 +34,11 @@ inner_port = 22
 mode = "unix"
 path = "../../serial.socket"
 
-[process.gpio.gpiochip1]
-mode = "external"
-path = "../../gpiochip1.socket"
+# FIXME: under Docker with ubuntu 24.04 base image, QEMU gets SIGBUS when
+# vhost-user-gpio is enabled
+#[process.gpio.gpiochip1]
+#mode = "external"
+#path = "../../gpiochip1.socket"
 
 
 # Ardupilot

--- a/src/vm_runner/tests/opensut-dev/logging_config.sh
+++ b/src/vm_runner/tests/opensut-dev/logging_config.sh
@@ -1,6 +1,6 @@
 export VERSE_LOG_DEVICE=/dev/vdc
 export VERSE_AUTOPILOT_HOST=10.0.2.2
-export MKM_HOST=10.0.2.2
+export VERSE_MKM_HOST=10.0.2.2
 
 echo "LOGGING DEBUG:"
 ip addr


### PR DESCRIPTION
Fixes #96 

EDIT: `docker/build-push-action@v6` does not seem to preserve the `.git` directories in the build context, so it is not possible to run `git` commands in the `COPY`-ed repo. Using plain `docker build` invocation on the other hand does not preserve the cache, but it keeps the git history.

Perhaps a suitable way forward is to run the docker build nightly, and always build it from scratch. After all, at some point we need to show how to build the system from scratch.