### PR TITLE
Add a simple helper program to request keys from the MKM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -561,3 +561,42 @@ jobs:
           run: |
               cd components/mission_key_management
               python3 run_tests.py
+
+  mkm_client:
+      runs-on: ubuntu-22.04
+      needs: trusted-boot-build
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
+        # mkm is trivial to build, so we don't bother packaging or caching it.
+        - name: Install dependencies
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y build-essential
+            sudo apt-get install -y {gcc,g++}-aarch64-linux-gnu
+        - name: Build mkm
+          run: |
+              cd components/mission_key_management
+              make
+              [ -f mkm ]
+        - name: Build mkm_client
+          run: |
+              cd components/mkm_client
+              make
+              [ -f mkm_client ]
+              make TARGET=aarch64
+              [ -f mkm_client.aarch64 ]
+        - name: Download trusted_boot binary
+          uses: actions/download-artifact@v4
+          with:
+            name: trusted-boot-binaries
+        - name: Move trusted_boot binary into place
+          run: |
+              chmod -v +x trusted_boot
+              mv -v trusted_boot components/platform_crypto/shave_trusted_boot/
+        - name: Run tests
+          run: |
+              cd components/mkm_client
+              ../mission_key_management/mkm &
+              key=$(../platform_crypto/shave_trusted_boot/trusted_boot ./run_client.sh)
+              [ "$key" = "mkm_client uses this key to test" ]

--- a/components/mission_key_management/cn_stubs.h
+++ b/components/mission_key_management/cn_stubs.h
@@ -70,3 +70,11 @@ ssize_t _write(int fildes, const void *buf, size_t nbyte);
     return >= -1i64 && return < (i64)nbyte;
 $*/
 #define write(f,b,s) _write(f,b,s)
+
+int _shutdown(int fildes, int how);
+/*$ spec _close(i32 fildes, i32 how);
+    requires true;
+    ensures true;
+$*/
+#define shutdown(x,h) _shutdown(x,h)
+

--- a/components/mission_key_management/mkm.c
+++ b/components/mission_key_management/mkm.c
@@ -36,6 +36,18 @@ int main() {
             test_attest_helper_measure,
             (const uint8_t*)"extra key for test_attest to use");
 
+    // Measure of `mkm_client`'s `run_client.sh` script.
+    static const uint8_t mkm_client_run_measure[MEASURE_SIZE] = {
+        0x5b, 0xfa, 0xa5, 0xe5, 0xed, 0xdc, 0xc3, 0x6e,
+        0x15, 0x5b, 0xde, 0x85, 0x9a, 0xc5, 0x5e, 0x52,
+        0x77, 0x93, 0x67, 0x91, 0x76, 0x1a, 0x34, 0xb2,
+        0xc6, 0xbc, 0xb5, 0xda, 0x81, 0xb4, 0x74, 0x6b
+    };
+    policy_add(
+            (const uint8_t*)"\0",
+            mkm_client_run_measure,
+            (const uint8_t*)"mkm_client uses this key to test");
+
 
     // Open the listening socket.
 

--- a/components/mkm_client/.gitignore
+++ b/components/mkm_client/.gitignore
@@ -1,0 +1,4 @@
+/build/
+/build.*/
+/mkm_client
+/mkm_client.*

--- a/components/mkm_client/Makefile
+++ b/components/mkm_client/Makefile
@@ -1,0 +1,36 @@
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+ifeq ($(TARGET),x86_64)
+CC = x86_64-linux-gnu-gcc
+CXX = x86_64-linux-gnu-g++
+else ifeq ($(TARGET),aarch64)
+CC = aarch64-linux-gnu-gcc
+CXX = aarch64-linux-gnu-g++
+else ifeq ($(TARGET),)
+# If target is unspecified, use gcc and its default target.
+CC = gcc
+CXX = g++
+else
+$(error "bad TARGET $(TARGET)")
+endif
+
+TARGET_SUFFIX = $(foreach x,$(TARGET),.$(x))
+BUILD_DIR = build$(TARGET_SUFFIX)
+
+MKM_CLIENT_BIN = mkm_client$(TARGET_SUFFIX)
+
+SRC = mkm_client.c
+OBJ = $(SRC:%.c=$(BUILD_DIR)/%.o)
+CFLAGS = -I$(ROOT_DIR) -Wall -Wextra -pedantic
+
+$(MKM_CLIENT_BIN): $(OBJ)
+	@mkdir -pv $(dir $@)
+	$(CC) $(CFLAGS) -o $@ $^
+
+$(BUILD_DIR)/%.o: $(ROOT_DIR)/%.c
+	@mkdir -pv $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+.PHONY: clean
+clean:
+	rm -rf build/ build.*/

--- a/components/mkm_client/README.md
+++ b/components/mkm_client/README.md
@@ -1,0 +1,31 @@
+# Mission Key Management Client
+
+This is a small helper program for requesting a key from the Mission Key
+Management component.  It connects to an MKM server and the local trusted boot
+daemon and requests a particular key ID.  The key received is written to
+stdout.  If the request fails for any reason, the client program exits nonzero.
+
+
+## Building
+
+To build the MKM client:
+
+```sh
+make
+```
+
+Or, to build an ARM binary for use inside the OpenSUT VMs:
+
+```sh
+make TARGET=aarch64
+```
+
+
+## Protocol
+
+See `../mission_key_management/README.md` for details on the protocol.
+
+The MKM client connects to localhost (127.0.0.1) port 6000 by default.  To
+change this, set the `MKM_HOST` and/or `MKM_PORT` environment variables.
+For example, `MKM_HOST=10.0.2.121 MKM_PORT=6001 ./mkm_client` will cause it to
+connect to port 6001 on 10.0.2.121.

--- a/components/mkm_client/mkm_client.c
+++ b/components/mkm_client/mkm_client.c
@@ -1,0 +1,248 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <limits.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#define KEY_ID_SIZE 1
+#define NONCE_SIZE 16
+#define MEASURE_SIZE 32
+#define HMAC_SIZE 32
+#define ATTESTATION_SIZE (MEASURE_SIZE + HMAC_SIZE)
+#define KEY_SIZE 32
+
+//#define MKM_CLIENT_DEBUG
+
+// Try to parse a string as an integer.  If parsing succeeds and the result is
+// positive and no greater than `limit`, the result is stored in `*out` and the
+// function returns `true`.  Otherwise, an error is printed to stderr, and the
+// function returns `false`.  This function may modify `*out` arbitrarily on
+// failure.
+bool parse_long(const char* str, long* out, const char* desc, long limit) {
+    if (str == NULL) {
+        fprintf(stderr, "error parsing %s: NULL input\n", desc);
+        return false;
+    }
+    if (*str == '\0') {
+        fprintf(stderr, "error parsing %s: empty input\n", desc);
+        return false;
+    }
+
+    char* end = NULL;
+    errno = 0;
+    *out = strtol(str, &end, 10);
+    if (errno != 0) {
+        fprintf(stderr, "error parsing %s: ", desc);
+        perror("strtol");
+        return false;
+    }
+    if (*end != '\0') {
+        fprintf(stderr, "error parsing %s: contains non-digit characters\n", desc);
+        return false;
+    }
+    if (*out < 0) {
+        fprintf(stderr, "error parsing %s: value must be nonnegative\n", desc);
+        return false;
+    }
+    if (*out > limit) {
+        fprintf(stderr, "error parsing %s: value %ld is too large (limit = %ld)\n",
+            desc, *out, limit);
+        return false;
+    }
+    return true;
+}
+
+
+// Read exactly `count` bytes from `fd` into `buf`.  This will make multiple
+// calls to `read` if needed.  Returns `true` on success; prints an error to
+// stderr (mentioning `desc`) and returns `false` on error.
+bool read_exact(int fd, void* buf, size_t count, const char* desc) {
+#ifdef MKM_CLIENT_DEBUG
+    fprintf(stderr, "read_exact: %s\n", desc);
+#endif
+    size_t pos = 0;
+    while (pos < count) {
+        ssize_t result = read(fd, (char*)buf + pos, count - pos);
+#ifdef MKM_CLIENT_DEBUG
+        fprintf(stderr, "read_exact: %s: %d\n", desc, (int)result);
+#endif
+        if (result < 0) {
+            fprintf(stderr, "error %s: ", desc);
+            perror("read");
+            return false;
+        } else if (result == 0) {
+            fprintf(stderr, "error %s: unexpected EOF\n", desc);
+            return false;
+        } else {
+            pos += result;
+        }
+    }
+    return true;
+}
+
+bool write_exact(int fd, void* buf, size_t count, const char* desc) {
+#ifdef MKM_CLIENT_DEBUG
+    fprintf(stderr, "write_exact: %s\n", desc);
+#endif
+    size_t pos = 0;
+    while (pos < count) {
+        ssize_t result = write(fd, (const char*)buf + pos, count - pos);
+#ifdef MKM_CLIENT_DEBUG
+        fprintf(stderr, "write_exact: %s: %d\n", desc, (int)result);
+#endif
+        if (result < 0) {
+            fprintf(stderr, "error %s: ", desc);
+            perror("write");
+            return false;
+        } else if (result == 0) {
+            fprintf(stderr, "error %s: unexpected EOF\n", desc);
+            return false;
+        } else {
+            pos += result;
+        }
+    }
+    return true;
+}
+
+
+int main(int argc, char *argv[]) {
+    int ret;
+
+
+    // Get the key ID from the command line arguments
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s KEY_ID\n", argc > 0 ? argv[0] : "./mkm_client");
+        return 1;
+    }
+
+    const char* key_id_str = argv[1];
+    long key_id_long;
+    ret = parse_long(key_id_str, &key_id_long, "key ID", (long)UINT8_MAX);
+    if (!ret) {
+        // `parse_long` already printed a message.
+        return 1;
+    }
+    uint8_t key_id = (uint8_t)key_id_long;
+
+
+    // Connect to the trusted boot daemon.
+    const char* boot_sock_str = getenv("VERSE_TRUSTED_BOOT_FD");
+    if (boot_sock_str == NULL) {
+        fprintf(stderr, "error connecting to trusted boot daemon: "
+            "$VERSE_TRUSTED_BOOT_FD is unset\n");
+        return 1;
+    }
+
+    long boot_sock_long;
+    ret = parse_long(boot_sock_str, &boot_sock_long, "$VERSE_TRUSTED_BOOT_FD", (long)INT_MAX);
+    if (!ret) {
+        return 1;
+    }
+    int boot_sock = (int)boot_sock_long;
+
+
+    // Connect to the MKM server.
+    int mkm_sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (mkm_sock < 0) {
+        perror("error creating MKM socket: socket");
+        return 1;
+    }
+
+    struct sockaddr_in host_addr = {0};
+    host_addr.sin_family = AF_INET;
+
+    const char* host_addr_str = getenv("MKM_HOST");
+    if (host_addr_str == NULL) {
+        host_addr_str = "127.0.0.1";
+    }
+    ret = inet_pton(host_addr.sin_family, host_addr_str, &host_addr.sin_addr);
+    if (ret == 0) {
+        fprintf(stderr, "bad address in $MKM_HOST: %s\n", host_addr_str);
+        return 1;
+    } else if (ret < 0) {
+        perror("error parsing MKM host address: inet_pton");
+        return 1;
+    }
+
+    uint16_t port = 6000;
+    const char* port_str = getenv("MKM_PORT");
+    if (port_str != NULL) {
+        long port_long;
+        ret = parse_long(port_str, &port_long, "port number", (long)UINT16_MAX);
+        if (!ret) {
+            return 1;
+        }
+        port = (int)port_long;
+    }
+    host_addr.sin_port = htons(port);
+
+    ret = connect(mkm_sock, (const struct sockaddr*)&host_addr, sizeof(host_addr));
+    if (ret != 0) {
+        perror("error connecting to MKM server: connect");
+        return 1;
+    }
+    fprintf(stderr, "connected to MKM server at %s:%d\n",
+        host_addr_str, ntohs(host_addr.sin_port));
+
+
+    // Run the protocol.
+    ret = write_exact(mkm_sock, &key_id, 1,
+        "sending key ID to MKM");
+    if (!ret) {
+        return 1;
+    }
+
+    uint8_t nonce[NONCE_SIZE];
+    ret = read_exact(mkm_sock, nonce, sizeof(nonce),
+        "receiving nonce from MKM");
+    if (!ret) {
+        return 1;
+    }
+
+    // Command 2 is the attest operation
+    uint8_t trusted_boot_cmd = 2;
+    ret = write_exact(boot_sock, &trusted_boot_cmd, 1,
+        "sending command to trusted boot daemon");
+    if (!ret) {
+        return 1;
+    }
+
+    ret = write_exact(boot_sock, nonce, sizeof(nonce),
+        "sending nonce to trusted boot daemon");
+    if (!ret) {
+        return 1;
+    }
+
+    uint8_t attestation[ATTESTATION_SIZE];
+    ret = read_exact(boot_sock, attestation, sizeof(attestation),
+        "receiving attestation from trusted boot daemon");
+    if (!ret) {
+        return 1;
+    }
+
+    ret = write_exact(mkm_sock, attestation, sizeof(attestation),
+        "sending attestation to MKM");
+    if (!ret) {
+        return 1;
+    }
+
+    uint8_t key[KEY_SIZE];
+    ret = read_exact(mkm_sock, key, sizeof(key),
+        "receiving key from MKM");
+    if (!ret) {
+        return 1;
+    }
+
+    ret = write_exact(1, key, sizeof(key),
+        "writing key to stdout");
+    if (!ret) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/components/mkm_client/run_client.sh
+++ b/components/mkm_client/run_client.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "$(dirname "$0")"/mkm_client 0


### PR DESCRIPTION
My current plan for the logging component (#120) is to write a shell script to set up the encrypted filesystem.  Querying the MKM directly from a shell script would be difficult, so this branch adds a small helper program called `mkm_client` that will connect to the MKM server and to the local trusted boot daemon, request a key, and (on success) print the key to stdout.  The logging component's startup script will use this to get an encryption key that it can pass to `cryptsetup` to open the encrypted filesystem.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] My code matches the coding standards and I have ran the appropriate linters
- [x] I included documentation updates for my code
- [x] I extended the test suite and the tests run by the CI to cover my code
- [x] I assigned a Milestone to this PR
- [x] I assigned this PR to a Project
- [x] I assigned this PR appropriate Labels
