### PR TITLE
autopilot: update ardupilot submodule

### DIFF
--- a/components/autopilot/README.md
+++ b/components/autopilot/README.md
@@ -39,7 +39,7 @@ On other OSes:
 To build the aarch64 binaries for running ArduPilot in the OpenSUT VMs:
 
 ```sh
-bash src/pkvm_setup/package.sh ardupilot
+bash src/pkvm_setup/package.sh full_build ardupilot
 ```
 
 Or, to build a native binary for testing:


### PR DESCRIPTION
This pulls https://github.com/GaloisInc/verse-ardupilot/pull/2, which allows setting a sim rate multiplier for `jsbsim_ext`, which is required for OpenSUT autopilot setup.
