### PR TITLE
ci: update from cache@v3 action to cache@v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
               echo "CACHE_KEY=$cache_key" >>$GITHUB_ENV
         - name: Cache results
           id: cache
-          uses: actions/cache@v3
+          uses: actions/cache@v4
           with:
               key: ${{ env.CACHE_KEY }}
               path: packages/${{ env.CACHE_KEY }}.tar.gz
@@ -40,7 +40,7 @@ jobs:
               tar -xvf packages/${{ env.CACHE_KEY }}.tar.gz
         - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
           name: "Cache restore: libgpiod"
-          uses: actions/cache/restore@v3
+          uses: actions/cache/restore@v4
           with:
               key: ${{ needs.libgpiod.outputs.CACHE_KEY }}
               path: packages/${{ needs.libgpiod.outputs.CACHE_KEY }}.tar.gz
@@ -127,7 +127,7 @@ jobs:
         echo "CACHE_KEY=$cache_key" >>$GITHUB_ENV
     - name: Cache results
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: ${{ env.CACHE_KEY }}
         path: packages/${{ env.CACHE_KEY }}.tar.gz
@@ -164,7 +164,7 @@ jobs:
         echo "CACHE_KEY=$cache_key" >>$GITHUB_ENV
     - name: Cache results
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: ${{ env.CACHE_KEY }}
         path: packages/${{ env.CACHE_KEY }}.tar.gz
@@ -201,13 +201,13 @@ jobs:
         echo "CACHE_KEY=$cache_key" >>$GITHUB_ENV
     - name: Cache results
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: ${{ env.CACHE_KEY }}
         path: packages/${{ env.CACHE_KEY }}.tar.gz
     - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: "Cache restore: libgpiod"
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         key: ${{ needs.libgpiod.outputs.CACHE_KEY }}
         path: packages/${{ needs.libgpiod.outputs.CACHE_KEY }}.tar.gz
@@ -248,7 +248,7 @@ jobs:
         echo "CACHE_KEY=$cache_key" >>$GITHUB_ENV
     - name: Cache results
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: ${{ env.CACHE_KEY }}
         path: packages/${{ env.CACHE_KEY }}.tar.gz
@@ -277,7 +277,7 @@ jobs:
         echo "CACHE_KEY=$cache_key" >>$GITHUB_ENV
     - name: Cache results
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: ${{ env.CACHE_KEY }}
         path: packages/${{ env.CACHE_KEY }}.tar.gz
@@ -302,7 +302,7 @@ jobs:
         echo "CACHE_KEY=$cache_key" >>$GITHUB_ENV
     - name: Cache results
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: ${{ env.CACHE_KEY }}
         path: packages/${{ env.CACHE_KEY }}.tar.gz
@@ -340,37 +340,37 @@ jobs:
         echo "CACHE_KEY=$cache_key" >>$GITHUB_ENV
     - name: Cache results
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: ${{ env.CACHE_KEY }}
         path: packages/${{ env.CACHE_KEY }}.tar.gz
     - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: "Cache restore: vm_runner"
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         key: ${{ needs.vm_runner.outputs.CACHE_KEY }}
         path: packages/${{ needs.vm_runner.outputs.CACHE_KEY }}.tar.gz
     - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: "Cache restore: vhost_device"
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         key: ${{ needs.vhost_device.outputs.CACHE_KEY }}
         path: packages/${{ needs.vhost_device.outputs.CACHE_KEY }}.tar.gz
     - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: "Cache restore: pkvm"
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         key: ${{ needs.pkvm.outputs.CACHE_KEY }}
         path: packages/${{ needs.pkvm.outputs.CACHE_KEY }}.tar.gz
     - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: "Cache restore: qemu"
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         key: ${{ needs.qemu.outputs.CACHE_KEY }}
         path: packages/${{ needs.qemu.outputs.CACHE_KEY }}.tar.gz
     - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       name: "Cache restore: vm_image_base"
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         key: ${{ needs.vm_image_base.outputs.CACHE_KEY }}
         path: packages/${{ needs.vm_image_base.outputs.CACHE_KEY }}.tar.gz
@@ -406,12 +406,12 @@ jobs:
         chmod +x mps.*
         mv mps.* components/mission_protection_system/src/.
     - name: "Cache restore: vm_images"
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         key: ${{ needs.vm_images.outputs.CACHE_KEY }}
         path: packages/${{ needs.vm_images.outputs.CACHE_KEY }}.tar.gz
     - name: "Cache restore: vhost_device"
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         key: ${{ needs.vhost_device.outputs.CACHE_KEY }}
         path: packages/${{ needs.vhost_device.outputs.CACHE_KEY }}.tar.gz
@@ -449,7 +449,7 @@ jobs:
               echo "CACHE_KEY=$cache_key" >>$GITHUB_ENV
         - name: Cache results
           id: cache
-          uses: actions/cache@v3
+          uses: actions/cache@v4
           with:
               key: ${{ env.CACHE_KEY }}
               path: packages/${{ env.CACHE_KEY }}.tar.gz
@@ -490,7 +490,7 @@ jobs:
               echo "CACHE_KEY=$cache_key" >>$GITHUB_ENV
         - name: Cache results
           id: cache
-          uses: actions/cache@v3
+          uses: actions/cache@v4
           with:
               key: ${{ env.CACHE_KEY }}
               path: packages/${{ env.CACHE_KEY }}.tar.gz


### PR DESCRIPTION
Caches created with the cache@v3 action don't show up in the Github Actions cache UI, making it hard to see the cache state or delete a bad cache while working on the CI configuration.
