### PR TITLE
Logging component startup script

### DIFF
--- a/components/logging/logging_boot.sh
+++ b/components/logging/logging_boot.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+set -e
+
+# Find the device that contains the logging filesystem.
+log_device="$VERSE_LOG_DEVICE"
+
+if [ -n "$log_device" ]; then
+    echo "found log device '$log_device' from \$VERSE_LOG_DEVICE" 1>&2
+fi
+
+if [ -z "$log_device" ]; then
+    # Read /proc/cmdline to find opensut.log_device setting
+    # https://stackoverflow.com/a/15027935
+    set -- $(cat /proc/cmdline)
+    for x in "$@"; do
+        case "$x" in
+            opensut.log_device=*)
+                log_device="${x#opensut.log_device=}"
+                echo "found log device '$log_device' from /proc/cmdline" 1>&2
+                ;;
+            # All other options are ignored
+        esac
+    done
+fi
+
+if [ -z "$log_device" ]; then
+    echo "error: couldn't find a log device from \$VERSE_LOG_DEVICE or /proc/cmdline" 1>&2
+    exit 1
+fi
+
+
+# Helper function for fetching the relevant key from the MKM.  Note that if the
+# key is needed multiple times (for example, to format the LUKS container and
+# then to open it), we request it again each time.  We can't store the key in a
+# shell variable because it might contain a null character, and we want to
+# avoid writing it to non-encrypted storage.
+mkm_client="${VERSE_MKM_CLIENT:-./mkm_client}"
+get_key() {
+    # TODO: set $MKM_HOST based on /proc/cmdline
+    "$mkm_client" 0
+}
+
+
+# Check that the log device has a LUKS container
+
+# First, make sure `cryptsetup` works and has LUKS support.  Otherwise we may
+# get false negatives when checking with `isLuks`.
+cryptsetup_suppots_luks() {
+    cryptsetup --help | grep isLuks >/dev/null 2>/dev/null
+}
+if ! cryptsetup_suppots_luks; then
+    echo "error: cryptsetup doesn't support LUKS encryption" 1>&2
+    exit 1
+fi
+
+if ! cryptsetup isLuks "$log_device"; then
+    echo "formatting uninitialized log device '$log_device'" 1>&2
+    get_key | cryptsetup luksFormat --key-file=- "$log_device"
+    get_key | cryptsetup luksOpen --key-file=- "$log_device" log_device
+    mkfs -t ext2 /dev/mapper/log_device
+else
+    # Device is already initialized - just open it.
+    get_key | cryptsetup luksOpen --key-file=- "$log_device" log_device
+fi
+
+mkdir -p /opt/opensut/log
+mount /dev/mapper/log_device /opt/opensut/log
+
+
+logging="${VERSE_LOGGING:-./logging}"
+# TODO: set telemetry host and port
+# TODO: if a real-time clock is unavailable, then the time will be the same on
+# each boot (e.g. Jan 1 1970), and newer logs will overwrite older ones.
+exec "$logging" >/opt/opensut/log/log-$(date +%Y%m%d-%H%M%S).txt

--- a/components/logging/logging_boot.sh
+++ b/components/logging/logging_boot.sh
@@ -2,6 +2,12 @@
 set -e
 
 
+# Get environment variables, if needed
+if [ -f ./logging_config.sh ]; then
+    . ./logging_config.sh
+fi
+
+
 # Parse /proc/cmdline and extract relevant opensut.* options
 # https://stackoverflow.com/a/15027935
 cmdline_log_device=

--- a/components/logging/logging_boot.sh
+++ b/components/logging/logging_boot.sh
@@ -50,6 +50,18 @@ else
     exit 1
 fi
 
+# Find MKM host and port
+if [ -n "${VERSE_MKM_HOST:-}" ]; then
+    mkm_host="$VERSE_MKM_HOST"
+    echo "using mkm host '$mkm_host' from \$VERSE_MKM_HOST" 1>&2
+elif [ -n "$cmdline_mkm_host" ]; then
+    mkm_host="$cmdline_mkm_host"
+    echo "using mkm host '$mkm_host' from /proc/cmdline" 1>&2
+else
+    mkm_host="127.0.0.1"
+    echo "using default mkm host '$mkm_host'" 1>&2
+fi
+
 # Find autopilot telemetry host and port
 if [ -n "${VERSE_AUTOPILOT_HOST:-}" ]; then
     autopilot_host="$VERSE_AUTOPILOT_HOST"
@@ -85,10 +97,8 @@ mkm_client="${VERSE_MKM_CLIENT:-./mkm_client}"
 get_key() {
     # Run in a subshell so changes to `$MKM_HOST` don't affect the caller.
     (
+        export MKM_HOST="$mkm_host"
         for try in `seq 1 10`; do
-            if [ -n "$cmdline_mkm_host" ]; then
-                export MKM_HOST="$cmdline_mkm_host"
-            fi
             local ret=0
             "$mkm_client" 0 || ret=$?
             if [ "$ret" -eq 0 ]; then

--- a/components/logging/logging_boot.sh
+++ b/components/logging/logging_boot.sh
@@ -12,6 +12,7 @@ fi
 # https://stackoverflow.com/a/15027935
 cmdline_log_device=
 cmdline_mkm_host=
+cmdline_mkm_port=
 cmdline_autopilot_host=
 cmdline_autopilot_port=
 set -- $(cat /proc/cmdline)
@@ -24,6 +25,10 @@ for x in "$@"; do
         opensut.mkm_host=*)
             cmdline_mkm_host="${x#opensut.mkm_host=}"
             echo "read mkm_host='$cmdline_mkm_host' from /proc/cmdline" 1>&2
+            ;;
+        opensut.mkm_port=*)
+            cmdline_mkm_port="${x#opensut.mkm_port=}"
+            echo "read mkm_port='$cmdline_mkm_port' from /proc/cmdline" 1>&2
             ;;
         opensut.autopilot_host=*)
             cmdline_autopilot_host="${x#opensut.autopilot_host=}"
@@ -60,6 +65,17 @@ elif [ -n "$cmdline_mkm_host" ]; then
 else
     mkm_host="127.0.0.1"
     echo "using default mkm host '$mkm_host'" 1>&2
+fi
+
+if [ -n "${VERSE_MKM_PORT:-}" ]; then
+    mkm_port="$VERSE_MKM_PORT"
+    echo "using mkm port '$mkm_port' from \$VERSE_MKM_PORT" 1>&2
+elif [ -n "$cmdline_mkm_port" ]; then
+    mkm_port="$cmdline_mkm_port"
+    echo "using mkm port '$mkm_port' from /proc/cmdline" 1>&2
+else
+    mkm_port="6000"
+    echo "using default mkm port '$mkm_port'" 1>&2
 fi
 
 # Find autopilot telemetry host and port

--- a/components/mkm_client/mkm_client.c
+++ b/components/mkm_client/mkm_client.c
@@ -181,6 +181,11 @@ int main(int argc, char *argv[]) {
     }
     host_addr.sin_port = htons(port);
 
+    char addr_buf[256] = {0};
+    fprintf(stderr, "connecting to %s:%d\n",
+        inet_ntop(host_addr.sin_family, &host_addr.sin_addr, addr_buf, sizeof(addr_buf)),
+        ntohs(host_addr.sin_port));
+
     ret = connect(mkm_sock, (const struct sockaddr*)&host_addr, sizeof(host_addr));
     if (ret != 0) {
         perror("error connecting to MKM server: connect");

--- a/src/pkvm_setup/build_pkvm.sh
+++ b/src/pkvm_setup/build_pkvm.sh
@@ -15,4 +15,7 @@ make ARCH=arm64 CC=clang CROSS_COMPILE=aarch64-linux-gnu- -j "$(nproc)" defconfi
 ./scripts/config -e CONFIG_GPIO_VIRTIO
 ./scripts/config -e CONFIG_I2C_VIRTIO
 
+# The dm-crypt module is used for LUKS disk encryption in the logging service.
+./scripts/config -m CONFIG_DM_CRYPT
+
 make ARCH=arm64 CC=clang CROSS_COMPILE=aarch64-linux-gnu- -j "$(nproc)" bindeb-pkg

--- a/src/pkvm_setup/create_disk_images.sh
+++ b/src/pkvm_setup/create_disk_images.sh
@@ -284,6 +284,24 @@ define_image guest_ardupilot
 # * IP: 10.0.2.122
 # * MAC: 00:50:56:02:02:04
 
+do_img_guest_mkm() {
+    edo derive_image "$(disk common_guest)" "$(disk guest_mkm).orig"
+    edo bash change_uuids.sh "$(disk common)" "$(disk guest_mkm).orig"
+    edo bash run_vm_script.sh "$(disk guest_mkm).orig" vm_scripts/setup_guest_mkm.sh
+}
+define_image guest_mkm
+# * IP: 10.0.2.123
+# * MAC: 00:50:56:02:03:04
+
+do_img_guest_logging() {
+    edo derive_image "$(disk common_guest)" "$(disk guest_logging).orig"
+    edo bash change_uuids.sh "$(disk common)" "$(disk guest_logging).orig"
+    edo bash run_vm_script.sh "$(disk guest_logging).orig" vm_scripts/setup_guest_logging.sh
+}
+define_image guest_logging
+# * IP: 10.0.2.124
+# * MAC: 00:50:56:02:04:04
+
 # How to add a new disk image:
 #
 # 1. Copy the `host1` or `guest_mps` block in this script, and update the image

--- a/src/pkvm_setup/package.sh
+++ b/src/pkvm_setup/package.sh
@@ -248,6 +248,9 @@ vm_images_list_outputs() {
     echo src/pkvm_setup/vms/disk_common_guest.img
     echo src/pkvm_setup/vms/disk_host1.img
     echo src/pkvm_setup/vms/disk_guest_mps.img
+    echo src/pkvm_setup/vms/disk_guest_ardupilot.img
+    echo src/pkvm_setup/vms/disk_guest_mkm.img
+    echo src/pkvm_setup/vms/disk_guest_logging.img
     echo src/pkvm_setup/vms/pkvm-boot/vmlinuz
     echo src/pkvm_setup/vms/pkvm-boot/initrd.img
     echo src/pkvm_setup/vms/opensut_boot.measure.txt

--- a/src/pkvm_setup/vm_scripts/setup_guest_logging.sh
+++ b/src/pkvm_setup/vm_scripts/setup_guest_logging.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+# Setup script to be run inside the host VM with `run_vm_script.sh`.
+
+echo "setup_guest_logging.sh ($0) running"
+
+edo() {
+    echo " >> $*"
+    "$@"
+}
+
+
+# Assign a new machine ID
+edo rm -f /etc/machine-id /var/lib/dbus/machine-id
+edo dbus-uuidgen --ensure=/etc/machine-id
+# With no argument, `--ensure` updates `/var/lib/dbus/machine-id`
+edo dbus-uuidgen --ensure
+
+# Change the hostname
+hostname=pkvm-guest-logging
+edo systemctl start systemd-hostnamed.service
+edo hostnamectl hostname "$hostname"
+edo sed -i -e "s/pkvm-guest/$hostname/g" /etc/hosts
+
+# Generate new SSH host keys
+edo rm -f /etc/ssh/ssh_host_*_key /etc/ssh/ssh_host_*_key.pub
+edo ssh-keygen -A
+
+
+# Set network configuration
+edo tee /etc/network/interfaces <<"EOF"
+source /etc/network/interfaces.d/*
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+auto enp0s4
+iface enp0s4 inet static
+  hwaddress ether 00:50:56:02:04:04
+  address 10.0.2.124/24
+  gateway 10.0.2.2
+EOF
+
+edo tee /etc/resolv.conf <<"EOF"
+nameserver 10.0.2.3
+EOF
+
+
+edo apt install -y cryptsetup
+
+
+edo apt clean
+edo fstrim -v /

--- a/src/pkvm_setup/vm_scripts/setup_guest_mkm.sh
+++ b/src/pkvm_setup/vm_scripts/setup_guest_mkm.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+# Setup script to be run inside the host VM with `run_vm_script.sh`.
+
+echo "setup_guest_mkm.sh ($0) running"
+
+edo() {
+    echo " >> $*"
+    "$@"
+}
+
+
+# Assign a new machine ID
+edo rm -f /etc/machine-id /var/lib/dbus/machine-id
+edo dbus-uuidgen --ensure=/etc/machine-id
+# With no argument, `--ensure` updates `/var/lib/dbus/machine-id`
+edo dbus-uuidgen --ensure
+
+# Change the hostname
+hostname=pkvm-guest-mkm
+edo systemctl start systemd-hostnamed.service
+edo hostnamectl hostname "$hostname"
+edo sed -i -e "s/pkvm-guest/$hostname/g" /etc/hosts
+
+# Generate new SSH host keys
+edo rm -f /etc/ssh/ssh_host_*_key /etc/ssh/ssh_host_*_key.pub
+edo ssh-keygen -A
+
+
+# Set network configuration
+edo tee /etc/network/interfaces <<"EOF"
+source /etc/network/interfaces.d/*
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+auto enp0s4
+iface enp0s4 inet static
+  hwaddress ether 00:50:56:02:03:04
+  address 10.0.2.123/24
+  gateway 10.0.2.2
+EOF
+
+edo tee /etc/resolv.conf <<"EOF"
+nameserver 10.0.2.3
+EOF
+
+
+edo apt clean
+edo fstrim -v /

--- a/src/vm_runner/src/config.rs
+++ b/src/vm_runner/src/config.rs
@@ -134,10 +134,18 @@ fn const_u32<const N: u32>() -> u32 {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct VmDisk {
+    /// Disk image format.  Currently `vm_runner` allows only "qcow2" and "raw" formats.  See
+    /// `qemu-img --help` for a list of all formats supported by QEMU.
     pub format: String,
+    /// Path to the disk image.
     pub path: PathBuf,
+    /// If set, QEMU treats the disk image as read-only.  The VM will not be able to write to the
+    /// corresponding virtual block device.
     #[serde(default = "const_bool::<false>")]
     pub read_only: bool,
+    /// If set, QEMU uses a temporary snapshot of the disk image instead of using it directly.  The
+    /// VM will be able to write to the virtual block device as normal, but its writes will be
+    /// discarded when QEMU exits and will have no effect on the underlying image.
     #[serde(default = "const_bool::<false>")]
     pub snapshot: bool,
 }

--- a/src/vm_runner/src/lib.rs
+++ b/src/vm_runner/src/lib.rs
@@ -277,6 +277,8 @@ fn build_vm_command(paths: &Paths, vm: &config::VmProcess, cmds: &mut Commands) 
         // Forbid characters that require escaping in QEMU device arguments.
         assert!(!needs_escaping_for_qemu(&d.path),
             "unsupported character in disk {} path: {:?}", name, d.path);
+        // Require `format` to be one of a few known valid formats.  This list can be extended as
+        // needed.
         assert!(["qcow2", "raw"].contains(&(&d.format as &str)),
             "unsupported format for disk {}: {:?}", name, d.format);
         let path = d.path.to_str().unwrap();

--- a/src/vm_runner/tests/opensut-dev/.gitignore
+++ b/src/vm_runner/tests/opensut-dev/.gitignore
@@ -1,0 +1,2 @@
+/mkm_config.bin
+/mkm_config.ini

--- a/src/vm_runner/tests/opensut-dev/ardupilot.sh
+++ b/src/vm_runner/tests/opensut-dev/ardupilot.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+APP_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Provide a writable directory for `arduplane`.  It tries to write two things:
+#  1. It saves the autopilot parameters to `./eeprom.bin`
+#  2. It writes JSBSim config files to various places in the `autotest`
+#     directory.  This directory path can be set with a command-line flag.
+: "${RUN_DIR:=/var/run/ardupilot}"
+mkdir -p "$RUN_DIR"
+cd "$RUN_DIR"
+
+# Remove old parameter storage so the autopilot always starts with the contents
+# of the `--defaults` file rather than carrying over changes between runs.
+rm -fv eeprom.bin
+
+# Directories where `arduplane` will try to write JSBSim configs
+mkdir -p autotest
+mkdir -p autotest/aircraft/Rascal
+
+# `--rate 250 --config 10` means that the autopilot runs at a 250 Hz update
+# rate and the simulator runs at 10x that rate, or 2500 Hz.
+"${APP_DIR}/arduplane" \
+    --synthetic-clock --speedup 1 --slave 0 \
+    --model jsbsim_ext \
+    --defaults "$APP_DIR/plane-jsbsim-ext.parm" \
+    --autotest-dir "$RUN_DIR/autotest" \
+    --sim-address 10.0.2.2 --sim-port-out 5505 --sim-port-in 5504 \
+    --rate 250 --config 10
+echo "arduplane exited with code $?"

--- a/src/vm_runner/tests/opensut-dev/base_nested.toml
+++ b/src/vm_runner/tests/opensut-dev/base_nested.toml
@@ -1,0 +1,131 @@
+mode = "manage"
+
+[paths]
+vhost_device_gpio = "../../../pkvm_setup/vhost-device/target/release/vhost-device-gpio"
+
+
+[[process]]
+type = "vm"
+kvm = false
+# Provide enough RAM to run several guests plus overhead.
+ram_mb = 4096
+kernel = "../../../pkvm_setup/vms/pkvm-boot/vmlinuz"
+initrd = "../../../pkvm_setup/vms/pkvm-boot/initrd.img"
+append = 'earlycon root=/dev/vda2 nokaslr kvm-arm.mode=protected systemd.unit=opensut-boot.target opensut.app_device=/dev/vdb'
+
+
+[process.disk.vda]
+format = "qcow2"
+path = "../../../pkvm_setup/vms/disk_host1.img"
+snapshot = true
+
+[process.disk.vdb]
+format = "raw"
+path = "host.img"
+read_only = true
+
+[process.disk.vdc]
+format = "qcow2"
+path = "../../../pkvm_setup/vms/disk_guest_mps.img"
+snapshot = true
+
+[process.disk.vdd]
+format = "qcow2"
+path = "../../../pkvm_setup/vms/disk_guest_ardupilot.img"
+snapshot = true
+
+[process.disk.vde]
+format = "qcow2"
+path = "../../../pkvm_setup/vms/disk_guest_mkm.img"
+snapshot = true
+
+[process.disk.vdf]
+format = "qcow2"
+path = "../../../pkvm_setup/vms/disk_guest_logging.img"
+snapshot = true
+
+
+[process.net.default]
+mode = "user"
+
+
+# Port forwarding for the ardupilot / flight simulator setup
+
+# ArduPilot SITL SERIAL0 socket.  MAVProxy connects to this for telemetry and
+# to control the plane.
+[process.net.default.port_forward.ardupilot_serial0]
+outer_port = 5760
+inner_host = "10.0.2.122"
+inner_port = 5760
+
+# ArduPilot SITL SERIAL2 socket.  The logging component can connect to this
+# port to receive telemetry.
+[process.net.default.port_forward.ardupilot_serial2]
+outer_port = 5762
+inner_host = "10.0.2.122"
+inner_port = 5762
+
+# jsbsim_ext port for receiving position updates from JSBSim.  These updates
+# are sent in FlightGear's FGNetFDM format, hence the name.
+[process.net.default.port_forward.ardupilot_flightgear]
+outer_port = 5504
+proto = "udp"
+inner_host = "10.0.2.122"
+inner_port = 5504
+
+
+# Allow external processes to access the MKM for testing.
+[process.net.default.port_forward.mkm]
+outer_port = 6000
+proto = "udp"
+inner_host = "10.0.2.123"
+inner_port = 6000
+
+
+# SSH access
+
+# From the base system, use port 8022 to connect to the host VM:
+#   ssh -o HostKeyAlias=host1.verse -o Port=8022 user@localhost
+[process.net.default.port_forward.ssh_host]
+outer_port = 8022
+inner_host = "10.0.2.111"
+inner_port = 22
+
+# From the base system, use ports 8023 and up to connect to the guest VMs:
+#   ssh -o HostKeyAlias=guest-ardupilot.verse -o Port=8024 user@localhost
+[process.net.default.port_forward.ssh_guest1]
+outer_port = 8023
+inner_host = "10.0.2.121"
+inner_port = 22
+
+[process.net.default.port_forward.ssh_guest2]
+outer_port = 8024
+inner_host = "10.0.2.122"
+inner_port = 22
+
+[process.net.default.port_forward.ssh_guest3]
+outer_port = 8025
+inner_host = "10.0.2.123"
+inner_port = 22
+
+[process.net.default.port_forward.ssh_guest4]
+outer_port = 8026
+inner_host = "10.0.2.124"
+inner_port = 22
+
+
+# Open a Unix socket to allow networking with a second host VM.
+[process.net.socket]
+mode = "unix"
+listen = "../../net.socket"
+
+
+# Virtual serial port and GPIO device for MPS
+
+[process.serial.hvc0]
+mode = "unix"
+path = "../../serial.socket"
+
+[process.gpio.gpiochip1]
+mode = "external"
+path = "../../gpiochip1.socket"

--- a/src/vm_runner/tests/opensut-dev/base_single.toml
+++ b/src/vm_runner/tests/opensut-dev/base_single.toml
@@ -1,0 +1,146 @@
+mode = "manage"
+
+[paths]
+vhost_device_gpio = "../../../pkvm_setup/vhost-device/target/release/vhost-device-gpio"
+
+
+# MPS
+[[process]]
+type = "vm"
+kvm = false
+kernel = "../../../pkvm_setup/vms/pkvm-boot/vmlinuz"
+initrd = "../../../pkvm_setup/vms/pkvm-boot/initrd.img"
+append = 'earlycon root=/dev/vda2 systemd.unit=opensut-boot.target opensut.app_device=/dev/vdb'
+
+[process.disk.vda]
+format = "qcow2"
+path = "../../../pkvm_setup/vms/disk_guest_mps.img"
+snapshot = true
+
+[process.disk.vdb]
+format = "raw"
+path = "guest_mps.img"
+read_only = true
+
+[process.net.default]
+mode = "user"
+
+[process.net.default.port_forward.ssh_guest1]
+outer_port = 8023
+inner_host = "10.0.2.121"
+inner_port = 22
+
+[process.serial.hvc0]
+mode = "unix"
+path = "../../serial.socket"
+
+[process.gpio.gpiochip1]
+mode = "external"
+path = "../../gpiochip1.socket"
+
+
+# Ardupilot
+[[process]]
+type = "vm"
+kvm = false
+kernel = "../../../pkvm_setup/vms/pkvm-boot/vmlinuz"
+initrd = "../../../pkvm_setup/vms/pkvm-boot/initrd.img"
+append = 'earlycon root=/dev/vda2 systemd.unit=opensut-boot.target opensut.app_device=/dev/vdb'
+
+[process.disk.vda]
+format = "qcow2"
+path = "../../../pkvm_setup/vms/disk_guest_ardupilot.img"
+snapshot = true
+
+[process.disk.vdb]
+format = "raw"
+path = "guest_ardupilot.img"
+read_only = true
+
+[process.net.default]
+mode = "user"
+
+[process.net.default.port_forward.ssh_guest2]
+outer_port = 8024
+inner_host = "10.0.2.122"
+inner_port = 22
+
+[process.net.default.port_forward.ardupilot_serial0]
+outer_port = 5760
+inner_host = "10.0.2.122"
+inner_port = 5760
+
+[process.net.default.port_forward.ardupilot_serial2]
+outer_port = 5762
+inner_host = "10.0.2.122"
+inner_port = 5762
+
+[process.net.default.port_forward.ardupilot_flightgear]
+outer_port = 5504
+proto = "udp"
+inner_host = "10.0.2.122"
+inner_port = 5504
+
+
+# MKM
+[[process]]
+type = "vm"
+kvm = false
+kernel = "../../../pkvm_setup/vms/pkvm-boot/vmlinuz"
+initrd = "../../../pkvm_setup/vms/pkvm-boot/initrd.img"
+append = 'earlycon root=/dev/vda2 systemd.unit=opensut-boot.target opensut.app_device=/dev/vdb'
+
+[process.disk.vda]
+format = "qcow2"
+path = "../../../pkvm_setup/vms/disk_guest_mkm.img"
+snapshot = true
+
+[process.disk.vdb]
+format = "raw"
+path = "guest_mkm.img"
+read_only = true
+
+[process.net.default]
+mode = "user"
+
+[process.net.default.port_forward.mkm]
+outer_port = 6000
+inner_host = "10.0.2.123"
+inner_port = 6000
+
+[process.net.default.port_forward.ssh_guest3]
+outer_port = 8025
+inner_host = "10.0.2.123"
+inner_port = 22
+
+
+# Logging
+[[process]]
+type = "vm"
+kvm = false
+kernel = "../../../pkvm_setup/vms/pkvm-boot/vmlinuz"
+initrd = "../../../pkvm_setup/vms/pkvm-boot/initrd.img"
+append = 'earlycon root=/dev/vda2 systemd.unit=opensut-trusted-boot.target opensut.app_device=/dev/vdb'
+#append = 'earlycon root=/dev/vda2 opensut.app_device=/dev/vdb'
+
+[process.disk.vda]
+format = "qcow2"
+path = "../../../pkvm_setup/vms/disk_guest_logging.img"
+snapshot = true
+
+[process.disk.vdb]
+format = "raw"
+path = "guest_logging.img"
+read_only = true
+
+[process.disk.vdc]
+format = "raw"
+path = "../../logging_data.img"
+
+[process.net.default]
+mode = "user"
+
+[process.net.default.port_forward.ssh_guest4]
+outer_port = 8026
+inner_host = "10.0.2.124"
+inner_port = 22

--- a/src/vm_runner/tests/opensut-dev/build_img.sh
+++ b/src/vm_runner/tests/opensut-dev/build_img.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+script_dir="$(dirname "$0")"
+
+python3 "$script_dir/../../build_application_image.py" \
+    -f "$script_dir/guest_mps.toml=runner.toml" \
+    -f "$script_dir/../../../../components/mission_protection_system/src/mps.no_self_test.aarch64=mps" \
+    -f "$script_dir/mps.sh" \
+    -o "$script_dir/guest_mps.img"
+
+python3 "$script_dir/../../build_application_image.py" \
+    -f "$script_dir/guest_ardupilot.toml=runner.toml" \
+    -f "$script_dir/../../../../components/autopilot/ardupilot/build.aarch64/sitl/bin/arduplane" \
+    -f "$script_dir/ardupilot.sh" \
+    -f "$script_dir/plane-jsbsim-ext.parm" \
+    -o "$script_dir/guest_ardupilot.img"
+
+python3 "$script_dir/../../build_application_image.py" \
+    -f "$script_dir/guest_logging.toml=runner.toml" \
+    -f "$script_dir/../../../../components/logging/logging.aarch64=logging" \
+    -f "$script_dir/../../../../components/mkm_client/mkm_client.aarch64=mkm_client" \
+    -f "$script_dir/../../../../components/logging/logging_boot.sh=logging.sh" \
+    -f "$script_dir/logging_config.sh" \
+    -o "$script_dir/guest_logging.img"
+
+# Generate MKM config
+measure_logging="$(
+    python3 "$script_dir/../../../../components/platform_crypto/shave_trusted_boot/calc_measure.py" \
+        --set "$(cat "$script_dir/../../../../src/pkvm_setup/vms/opensut_boot.measure.txt")" \
+        --measure-hash-of-file "$script_dir/guest_logging.img" \
+        | head -n 1
+)"
+cat >"$script_dir/mkm_config.ini" <<EOF
+[${measure_logging}]
+key0 = 6e79d128effe911273bceb4df884021b63f8d0f81a4d80db90ec5d4ffa8fca9b
+EOF
+python3 "$script_dir/../../../../components/mission_key_management/convert_config.py" \
+    "$script_dir/mkm_config.ini" "$script_dir/mkm_config.bin"
+
+python3 "$script_dir/../../build_application_image.py" \
+    -f "$script_dir/guest_mkm.toml=runner.toml" \
+    -f "$script_dir/../../../../components/mission_key_management/mkm.aarch64=mkm" \
+    -f "$script_dir/mkm.sh" \
+    -f "$script_dir/mkm_config.bin" \
+    -o "$script_dir/guest_mkm.img"
+
+python3 "$script_dir/../../build_application_image.py" \
+    -f "$script_dir/host.toml=runner.toml" \
+    -f "$script_dir/guest_mps.img" \
+    -f "$script_dir/guest_ardupilot.img" \
+    -f "$script_dir/guest_mkm.img" \
+    -f "$script_dir/guest_logging.img" \
+    -o "$script_dir/host.img"

--- a/src/vm_runner/tests/opensut-dev/guest_ardupilot.toml
+++ b/src/vm_runner/tests/opensut-dev/guest_ardupilot.toml
@@ -1,0 +1,5 @@
+mode = "exec"
+
+[[process]]
+type = "shell"
+command = "./ardupilot.sh"

--- a/src/vm_runner/tests/opensut-dev/guest_logging.toml
+++ b/src/vm_runner/tests/opensut-dev/guest_logging.toml
@@ -1,0 +1,5 @@
+mode = "exec"
+
+[[process]]
+type = "shell"
+command = "./logging.sh"

--- a/src/vm_runner/tests/opensut-dev/guest_mkm.toml
+++ b/src/vm_runner/tests/opensut-dev/guest_mkm.toml
@@ -1,0 +1,5 @@
+mode = "exec"
+
+[[process]]
+type = "shell"
+command = "./mkm.sh"

--- a/src/vm_runner/tests/opensut-dev/guest_mps.toml
+++ b/src/vm_runner/tests/opensut-dev/guest_mps.toml
@@ -1,0 +1,5 @@
+mode = "exec"
+
+[[process]]
+type = "shell"
+command = "./mps.sh"

--- a/src/vm_runner/tests/opensut-dev/host.toml
+++ b/src/vm_runner/tests/opensut-dev/host.toml
@@ -1,0 +1,96 @@
+mode = "manage"
+
+[paths]
+vhost_device_gpio = "/opt/opensut/bin/vhost-device-gpio"
+
+
+# MPS
+[[process]]
+type = "vm"
+kvm = true
+kernel = "/boot/vmlinuz"
+initrd = "/boot/initrd.img"
+append = 'earlycon root=/dev/vda2 systemd.unit=opensut-boot.target opensut.app_device=/dev/vdb'
+
+[process.disk.vda]
+format = "raw"
+path = "/dev/vdc"
+
+[process.disk.vdb]
+format = "raw"
+path = "/opt/opensut/app/guest_mps.img"
+read_only = true
+
+[process.net.bridge]
+mode = "bridge"
+
+[process.serial.hvc0]
+mode = "passthrough"
+device = "/dev/hvc0"
+
+[process.gpio.gpiochip1]
+mode = "passthrough"
+device = "/dev/gpiochip1"
+
+
+# Ardupilot
+[[process]]
+type = "vm"
+kvm = true
+kernel = "/boot/vmlinuz"
+initrd = "/boot/initrd.img"
+append = 'earlycon root=/dev/vda2 systemd.unit=opensut-boot.target opensut.app_device=/dev/vdb'
+
+[process.disk.vda]
+format = "raw"
+path = "/dev/vdd"
+
+[process.disk.vdb]
+format = "raw"
+path = "/opt/opensut/app/guest_ardupilot.img"
+read_only = true
+
+[process.net.bridge]
+mode = "bridge"
+
+
+# MKM
+[[process]]
+type = "vm"
+kvm = true
+kernel = "/boot/vmlinuz"
+initrd = "/boot/initrd.img"
+append = 'earlycon root=/dev/vda2 systemd.unit=opensut-boot.target opensut.app_device=/dev/vdb'
+
+[process.disk.vda]
+format = "raw"
+path = "/dev/vde"
+
+[process.disk.vdb]
+format = "raw"
+path = "/opt/opensut/app/guest_mkm.img"
+read_only = true
+
+[process.net.bridge]
+mode = "bridge"
+
+
+# Logging
+[[process]]
+type = "vm"
+kvm = true
+kernel = "/boot/vmlinuz"
+initrd = "/boot/initrd.img"
+append = 'earlycon root=/dev/vda2 systemd.unit=opensut-boot.target opensut.app_device=/dev/vdb'
+
+[process.disk.vda]
+format = "raw"
+path = "/dev/vdf"
+
+[process.disk.vdb]
+format = "raw"
+path = "/opt/opensut/app/guest_logging.img"
+read_only = true
+
+[process.net.bridge]
+mode = "bridge"

--- a/src/vm_runner/tests/opensut-dev/logging_config.sh
+++ b/src/vm_runner/tests/opensut-dev/logging_config.sh
@@ -1,0 +1,8 @@
+export VERSE_LOG_DEVICE=/dev/vdc
+export VERSE_AUTOPILOT_HOST=10.0.2.2
+export MKM_HOST=10.0.2.2
+
+echo "LOGGING DEBUG:"
+ip addr
+ip route
+echo "END OF LOGGING DEBUG"

--- a/src/vm_runner/tests/opensut-dev/mkm.sh
+++ b/src/vm_runner/tests/opensut-dev/mkm.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+mkm_bin="$(dirname "$0")/mkm"
+sha256sum "$mkm_bin"
+
+export MKM_BIND_ADDR=10.0.2.123
+
+echo "Starting mkm"
+"$mkm_bin" mkm_config.bin
+echo "mkm exited with code $?"

--- a/src/vm_runner/tests/opensut-dev/mps.sh
+++ b/src/vm_runner/tests/opensut-dev/mps.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+mps_bin="$(dirname "$0")/mps"
+sha256sum "$mps_bin"
+
+# `host.toml` runs the guest VM with a virtual GPIO device as /dev/gpiochip1
+export MPS_GPIO_DEVICE=/dev/gpiochip1
+
+echo "Starting mps"
+setsid -c "$mps_bin" </dev/hvc0 >/dev/hvc0
+echo "mps exited with code $?"

--- a/src/vm_runner/tests/opensut-dev/plane-jsbsim-ext.parm
+++ b/src/vm_runner/tests/opensut-dev/plane-jsbsim-ext.parm
@@ -1,0 +1,98 @@
+# Copied from ardupilot/Tools/autotest/default_params/plane-jsbsim.parm, with
+# tweaks to work with the modified sim rate.
+
+EK2_ENABLE      1
+BATT_MONITOR    4
+LOG_BITMASK	65535
+AIRSPEED_CRUISE 22.00
+PTCH_TRIM_DEG 0.00
+TRIM_THROTTLE   50
+PTCH_LIM_MIN_DEG -20.00
+PTCH_LIM_MAX_DEG 25.00
+ROLL_LIMIT_DEG 65.00
+LAND_DISARMDELAY 3
+LAND_PITCH_DEG 1.00
+LAND_FLARE_SEC  3
+ARSPD_USE       1
+AIRSPEED_MAX   30
+AIRSPEED_MIN   10
+KFF_RDDRMIX     0.5
+THR_MAX		100
+RC2_REVERSED	1
+RC4_REVERSED	1
+SERVO2_REVERSED 1
+SERVO4_REVERSED 1
+RC1_MAX         2000
+RC1_MIN         1000
+RC1_TRIM        1500
+RC2_MAX         2000
+RC2_MIN         1000
+RC2_TRIM        1500
+RC3_MAX         2000
+RC3_MIN         1000
+RC3_TRIM        1000
+SERVO3_MIN      1000
+SERVO3_MAX      2000
+RC4_MAX         2000
+RC4_MIN         1000
+RC4_TRIM        1500
+RC5_MAX         2000
+RC5_MIN         1000
+RC5_TRIM        1500
+RC6_MAX         2000
+RC6_MIN         1000
+RC6_TRIM        1500
+RC7_MAX         2000
+RC7_MIN         1000
+RC7_TRIM        1500
+RC8_MAX         2000
+RC8_MIN         1000
+RC8_TRIM        1500
+FLTMODE1        10
+FLTMODE2        11
+FLTMODE3        12
+FLTMODE4        5
+FLTMODE5        2
+FLTMODE6        0
+FLTMODE_CH      8
+WP_LOITER_RAD   80
+WP_RADIUS       50
+RLL2SRV_RMAX     90
+RLL2SRV_TCONST   0.250000
+RLL_RATE_D       0.017430
+RLL_RATE_FF      0.237212
+RLL_RATE_I       0.25
+RLL_RATE_P       0.3
+PTCH2SRV_RMAX_DN 90
+PTCH2SRV_RMAX_UP 90
+PTCH2SRV_TCONST  0.25
+PTCH_RATE_D      0.007265
+PTCH_RATE_FF     0.595723
+PTCH_RATE_I      0.11
+PTCH_RATE_P      0.15
+PTCH2SRV_RLL     1
+# Increase NAVL1_PERIOD from 15 to 25, which seems to help correct for other
+# parameters being mistuned.  (Specifically, the parameters were tuned for the
+# original 1200 Hz update rate, and we haven't adjusted them for the lower
+# update rate we use.)
+NAVL1_PERIOD     25
+# Increase NAVL1_DAMPING from 0.75 (default) to 0.85.  This reduces (but
+# doesn't fully eliminate) the autopilot's propensity for making abrupt
+# maneuvers that send it off course.
+# from making
+NAVL1_DAMPING    0.85
+ACRO_LOCKING     1
+# we need small INS_ACC offsets so INS is recognised as being calibrated
+INS_ACCOFFS_X   0.001
+INS_ACCOFFS_Y   0.001
+INS_ACCOFFS_Z   0.001
+INS_ACCSCAL_X   1.001
+INS_ACCSCAL_Y   1.001
+INS_ACCSCAL_Z   1.001
+INS_ACC2OFFS_X   0.001
+INS_ACC2OFFS_Y   0.001
+INS_ACC2OFFS_Z   0.001
+INS_ACC2SCAL_X   1.001
+INS_ACC2SCAL_Y   1.001
+INS_ACC2SCAL_Z   1.001
+INS_GYR_CAL      0


### PR DESCRIPTION
This adds a startup script for the logging component.  The script requests a key from the MKM, uses the key to set up disk encryption, and starts the logger to write autopilot telemetry to the encrypted partition.

This PR has several pieces:

* The logging script itself
* New disk images for the logging and MKM guest VMs, so the VMs can all be run together alongside the autopilot
* A pKVM kernel configuration change to enable disk encryption within the guest VMs
* `vm_runner` configs for starting the MKM, autopilot, logging, and MPS guests in parallel

Once the VMs have started up, you should be able to connect to the autopilot as described in `components/autopilot/README.md` and run the mission.  Then, after shutting down the VMs, you can open the encrypted disk image with `cryptsetup luksOpen` and the key from `src/vm_runner/tests/opensut-dev/mkm_config.ini` (this is the same key that the MKM provides to the logging component), mount the partition, and view the logs.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] My code matches the coding standards and I have ran the appropriate linters
- [x] I included documentation updates for my code
- [x] I extended the test suite and the tests run by the CI to cover my code
- [x] I assigned a Milestone to this PR
- [x] I assigned this PR to a Project
- [x] I assigned this PR appropriate Labels
