### PR TITLE
Fix interleaving when running multiple OpenSUT guests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,6 +130,8 @@ WORKDIR /opt/OpenSUT/components/autopilot
 RUN bash jsbsim_build.sh
 
 # Adjust vm_runner configs for use in Docker
+# This must run before `build_img.sh`, since some of these configs get built
+# into the various application images.
 WORKDIR /opt/OpenSUT/src/vm_runner
 RUN sed -i -e '/##DOCKER/s/^#//' -e '/##NOT-DOCKER/s/^/#/' tests/*/*.toml
 

--- a/docs/OPENSUT_DOCKER.md
+++ b/docs/OPENSUT_DOCKER.md
@@ -87,19 +87,25 @@ OpenSUT:
 
 ```sh
 cd src/vm_runner
-# FIXME: Switch to base_nested.toml to run the full nested OpenSUT setup
-target/release/opensut_vm_runner tests/opensut-dev/base_single.toml
+target/release/opensut_vm_runner tests/opensut-dev/base_nested.toml
 ```
 
-Wait for the various OpenSUT VMs to boot.  Usually the logging component is the
-last to start up; once it starts printing messages like these, the system is
-usually ready:
+Wait for the various OpenSUT VMs to boot.  The logging component is typically
+the last to start up; once it starts printing messages like these, the system
+is usually ready:
 
 ```
-[   35.861091] trusted_boot[276]: connection closed (will retry)
-[   37.865934] trusted_boot[276]: connection closed (will retry)
-[   39.869003] trusted_boot[276]: connection closed (will retry)
+[  192.441966] opensut_boot[367]: [  164.897292] trusted_boot[273]: connect error (will retry): Connection refused
+[  194.517320] opensut_boot[367]: [  166.911533] trusted_boot[273]: connect error (will retry): Connection refused
+[  196.506175] opensut_boot[367]: [  168.911342] trusted_boot[273]: connect error (will retry): Connection refused
 ```
+
+The other components write their output to separate files to avoid causing
+confusion by interleaving messages.  If you need to inspect their output, open
+a new tmux window by pressing `^B` `c`, examine the files
+`src/vm_runner/serial.*.txt` (`tail -F` may be useful for following the boot
+process of a specific component), and finally close the tmux window by pressing
+`^D` at the shell.
 
 Now, in a separate terminal on the base system, run MAVProxy:
 
@@ -127,8 +133,17 @@ The plane will continue flying until manually stopped.  To stop it:
    both MAVProxy windows.
 2. In the container, switch to tmux window 0 by pressing `^B` `0`, then press
    `^C` to stop JSBSim.
-3. Switch to tmux window 1 by pressing `^B` `1`.  Press `^B` `x` to close the
-   window and stop the OpenSUT VMs, then press `y` to confirm.
+3. Switch to tmux window 1 by pressing `^B` `1`.  Wait for the logging
+   component to shut down, as indicated by the following messages:
+   ```
+   [  365.446443] opensut_boot[367]: [  342.192954] systemd-shutdown[1]: All filesystems, swaps, loop devices, MD devices and DM devices detached.
+   [  365.576932] opensut_boot[367]: [  342.349081] systemd-shutdown[1]: Syncing filesystems and block devices.
+   [  365.649712] opensut_boot[367]: [  342.441684] systemd-shutdown[1]: Powering off.
+   ...
+   [  365.964894] opensut_boot[367]: [  342.758193] reboot: Power down
+   ```
+   Press `^B` `x` to close the window and stop the remaining OpenSUT VMs, then
+   press `y` to confirm.
 
 ## Read the logs
 

--- a/src/pkvm_setup/vm_scripts/setup_common_guest.sh
+++ b/src/pkvm_setup/vm_scripts/setup_common_guest.sh
@@ -34,3 +34,9 @@ edo usermod -a -G kvm user
 edo tee -a /etc/sudoers <<EOF
 user ALL=(ALL) NOPASSWD: ALL
 EOF
+
+
+# Increase systemd device timeout from 90s to 300s.  On slower machines, it may
+# take ~120s for udev to populate /dev/disk/by-uuid/.
+edo sed -i -e 's/#\?DefaultDeviceTimeoutSec=.*/DefaultDeviceTimeoutSec=300s/' \
+    /etc/systemd/system.conf

--- a/src/vm_runner/src/config.rs
+++ b/src/vm_runner/src/config.rs
@@ -277,6 +277,8 @@ pub enum VmSerial {
     /// Listen for a Unix socket connection on the host, and connect it to the serial port in the
     /// guest.
     Unix(UnixSerial),
+    /// Write output to a file, and provide no input.
+    File(FileSerial),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -288,6 +290,12 @@ pub struct PassthroughSerial {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct UnixSerial {
+    pub path: PathBuf,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FileSerial {
     pub path: PathBuf,
 }
 
@@ -419,6 +427,7 @@ impl VmSerial {
             VmSerial::Stdio => {},
             VmSerial::Passthrough(ref mut ps) => ps.resolve_relative_paths(base),
             VmSerial::Unix(ref mut us) => us.resolve_relative_paths(base),
+            VmSerial::File(ref mut fs) => fs.resolve_relative_paths(base),
         }
     }
 }
@@ -433,6 +442,13 @@ impl PassthroughSerial {
 impl UnixSerial {
     pub fn resolve_relative_paths(&mut self, base: &Path) {
         let UnixSerial { ref mut path } = *self;
+        resolve_relative_path(path, base);
+    }
+}
+
+impl FileSerial {
+    pub fn resolve_relative_paths(&mut self, base: &Path) {
+        let FileSerial { ref mut path } = *self;
         resolve_relative_path(path, base);
     }
 }

--- a/src/vm_runner/src/lib.rs
+++ b/src/vm_runner/src/lib.rs
@@ -235,6 +235,14 @@ fn build_vm_command(paths: &Paths, vm: &config::VmProcess, cmds: &mut Commands) 
                     &format!("socket,id=char_{},path={},server=on,wait=off", name, path)]);
                 format!("char_{}", name)
             },
+            VmSerial::File(ref fs) => {
+                assert!(!needs_escaping_for_qemu(&fs.path),
+                    "unsupported character in serial {} path: {:?}", name, fs.path);
+                let path = fs.path.to_str().unwrap();
+                vm_cmd.args(&["-chardev",
+                    &format!("file,id=char_{},path={}", name, path)]);
+                format!("char_{}", name)
+            },
         }
     }
 

--- a/src/vm_runner/tests/opensut-dev/base_nested.toml
+++ b/src/vm_runner/tests/opensut-dev/base_nested.toml
@@ -82,6 +82,8 @@ mode = "user"
 # ArduPilot SITL SERIAL0 socket.  MAVProxy connects to this for telemetry and
 # to control the plane.
 [process.net.default.port_forward.ardupilot_serial0]
+#outer_host = "0.0.0.0"     ##DOCKER
+outer_host = "127.0.0.1"    ##NOT-DOCKER
 outer_port = 5760
 inner_host = "10.0.2.122"
 inner_port = 5760

--- a/src/vm_runner/tests/opensut-dev/base_nested.toml
+++ b/src/vm_runner/tests/opensut-dev/base_nested.toml
@@ -44,6 +44,10 @@ format = "qcow2"
 path = "../../../pkvm_setup/vms/disk_guest_logging.img"
 snapshot = true
 
+[process.disk.vdg]
+format = "raw"
+path = "../../logging_data.img"
+
 
 [process.net.default]
 mode = "user"
@@ -126,6 +130,8 @@ listen = "../../net.socket"
 mode = "unix"
 path = "../../serial.socket"
 
-[process.gpio.gpiochip1]
-mode = "external"
-path = "../../gpiochip1.socket"
+# FIXME: under Docker with ubuntu 24.04 base image, QEMU gets SIGBUS when
+# vhost-user-gpio is enabled
+[process.gpio.gpiochip1]            ##NOT-DOCKER
+mode = "external"                   ##NOT-DOCKER
+path = "../../gpiochip1.socket"     ##NOT-DOCKER

--- a/src/vm_runner/tests/opensut-dev/base_nested.toml
+++ b/src/vm_runner/tests/opensut-dev/base_nested.toml
@@ -49,6 +49,30 @@ format = "raw"
 path = "../../logging_data.img"
 
 
+# Virtual serial ports.  We have one port per guest so their outputs don't get
+# interleaved.  There's an additional port for communicating with the MPS.
+
+[process.serial.hvc0]
+mode = "file"
+path = "../../serial.mps.txt"
+
+[process.serial.hvc1]
+mode = "file"
+path = "../../serial.ardupilot.txt"
+
+[process.serial.hvc2]
+mode = "file"
+path = "../../serial.mkm.txt"
+
+[process.serial.hvc3]
+mode = "file"
+path = "../../serial.logging.txt"
+
+[process.serial.hvc4]
+mode = "unix"
+path = "../../serial.socket"
+
+
 [process.net.default]
 mode = "user"
 
@@ -124,11 +148,7 @@ mode = "unix"
 listen = "../../net.socket"
 
 
-# Virtual serial port and GPIO device for MPS
-
-[process.serial.hvc0]
-mode = "unix"
-path = "../../serial.socket"
+# Virtual GPIO device for MPS
 
 # FIXME: under Docker with ubuntu 24.04 base image, QEMU gets SIGBUS when
 # vhost-user-gpio is enabled

--- a/src/vm_runner/tests/opensut-dev/base_single.toml
+++ b/src/vm_runner/tests/opensut-dev/base_single.toml
@@ -124,7 +124,7 @@ type = "vm"
 kvm = false
 kernel = "../../../pkvm_setup/vms/pkvm-boot/vmlinuz"
 initrd = "../../../pkvm_setup/vms/pkvm-boot/initrd.img"
-append = 'earlycon root=/dev/vda2 systemd.unit=opensut-trusted-boot.target opensut.app_device=/dev/vdb'
+append = 'earlycon root=/dev/vda2 systemd.unit=opensut-trusted-boot.target opensut.app_device=/dev/vdb opensut.autopilot_host=10.0.2.2 opensut.mkm_host=10.0.2.2'
 #append = 'earlycon root=/dev/vda2 opensut.app_device=/dev/vdb'
 
 [process.disk.vda]

--- a/src/vm_runner/tests/opensut-dev/host.toml
+++ b/src/vm_runner/tests/opensut-dev/host.toml
@@ -24,9 +24,13 @@ read_only = true
 [process.net.bridge]
 mode = "bridge"
 
-[process.serial.hvc0]
+[process.serial.ttyAMA0]
 mode = "passthrough"
 device = "/dev/hvc0"
+
+[process.serial.hvc0]
+mode = "passthrough"
+device = "/dev/hvc4"
 
 # FIXME: under Docker with ubuntu 24.04 base image, QEMU gets SIGBUS when
 # vhost-user-gpio is enabled
@@ -55,6 +59,10 @@ read_only = true
 [process.net.bridge]
 mode = "bridge"
 
+[process.serial.ttyAMA0]
+mode = "passthrough"
+device = "/dev/hvc1"
+
 
 # MKM
 [[process]]
@@ -75,6 +83,10 @@ read_only = true
 
 [process.net.bridge]
 mode = "bridge"
+
+[process.serial.ttyAMA0]
+mode = "passthrough"
+device = "/dev/hvc2"
 
 
 # Logging
@@ -100,3 +112,12 @@ path = "/dev/vdg"
 
 [process.net.bridge]
 mode = "bridge"
+
+# Pass through this VM's output to the console so the user can see when it's
+# finished booting.  We can only pass through one VM this way (otherwise the
+# output is interleaved in a way that makes it unreadable), so output from the
+# other guests is redirected to a file on the base system (via the host's
+# /dev/hvc* serial ports).
+#[process.serial.ttyAMA0]
+#mode = "passthrough"
+#device = "/dev/hvc3"

--- a/src/vm_runner/tests/opensut-dev/host.toml
+++ b/src/vm_runner/tests/opensut-dev/host.toml
@@ -28,9 +28,11 @@ mode = "bridge"
 mode = "passthrough"
 device = "/dev/hvc0"
 
-[process.gpio.gpiochip1]
-mode = "passthrough"
-device = "/dev/gpiochip1"
+# FIXME: under Docker with ubuntu 24.04 base image, QEMU gets SIGBUS when
+# vhost-user-gpio is enabled
+[process.gpio.gpiochip1]        ##NOT-DOCKER
+mode = "passthrough"            ##NOT-DOCKER
+device = "/dev/gpiochip1"       ##NOT-DOCKER
 
 
 # Ardupilot
@@ -81,7 +83,7 @@ type = "vm"
 kvm = true
 kernel = "/boot/vmlinuz"
 initrd = "/boot/initrd.img"
-append = 'earlycon root=/dev/vda2 systemd.unit=opensut-boot.target opensut.app_device=/dev/vdb'
+append = 'earlycon root=/dev/vda2 systemd.unit=opensut-trusted-boot.target opensut.app_device=/dev/vdb opensut.autopilot_host=10.0.2.122 opensut.mkm_host=10.0.2.123'
 
 [process.disk.vda]
 format = "raw"
@@ -91,6 +93,10 @@ path = "/dev/vdf"
 format = "raw"
 path = "/opt/opensut/app/guest_logging.img"
 read_only = true
+
+[process.disk.vdc]
+format = "raw"
+path = "/dev/vdg"
 
 [process.net.bridge]
 mode = "bridge"

--- a/src/vm_runner/tests/opensut-dev/logging_config.sh
+++ b/src/vm_runner/tests/opensut-dev/logging_config.sh
@@ -1,8 +1,4 @@
 export VERSE_LOG_DEVICE=/dev/vdc
-export VERSE_AUTOPILOT_HOST=10.0.2.2
-export VERSE_MKM_HOST=10.0.2.2
-
-echo "LOGGING DEBUG:"
-ip addr
-ip route
-echo "END OF LOGGING DEBUG"
+# autopilot_host and mkm_host are set through /proc/cmdline.  These vary
+# depending on the configuration: for base_single.toml, both are set to
+# 10.0.2.2, but for base_nested.toml, they are 10.0.2.122 and 10.0.2.123.


### PR DESCRIPTION
Currently, running multiple OpenSUT guest VMs under the same host VM causes the output to be interleaved, making it completely unreadable.  This branch redirects the guest output to separate files in the nested configuration, so each guest's output can be viewed separately.  This has three parts:

1. In `vm_runner`, add a new `mode = "file"` option for virtual serial ports that sends the output to a file.
2. Update the `opensut-dev` `base_nested.toml` and `host.toml` configs to send each guest's output to a separate file on the base system.  This fixes the interleaving.
3. Update the `OPENSUT_DOCKER.md` instructions to work with the new `base_nested.toml`.

As an exception, the output from the logging component guest VM is still sent to the console, not to a file.  The logging component is usually the last to start up, and the instructions at one point direct the use to wait for the logging component to finish booting before proceeding, so it's useful for the logging output to be immediately visible.  Since no other guest VM outputs to the host console, this doesn't result in interleaving.

Fixes #155

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] My code matches the coding standards and I have ran the appropriate linters
- [x] I included documentation updates for my code
- [x] I extended the test suite and the tests run by the CI to cover my code
- [x] I assigned a Milestone to this PR
- [x] I assigned this PR to a Project
- [x] I assigned this PR appropriate Labels
