### PR TITLE
ci: tag docker image based on branch/tag being built

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
   #workflow_dispatch:
 
 env:
-  OPENSUT_BASE_IMAGE_ID: ghcr.io/galoisinc/verse-opensut/opensut-base:latest
+  OPENSUT_BASE_IMAGE_ID: ghcr.io/galoisinc/verse-opensut/opensut-base
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -723,9 +723,45 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.VERSE_OPENSUT_ACCESS_TOKEN }}
+    - name: Calculate Docker image tag
+      # Bash supports the non-POSIX `${var//search/replace}` syntax.
+      shell: bash
+      run: |
+        ref_type="${{ github.ref_type }}"
+        ref_name="${{ github.ref_name }}"
+        case "$ref_type" in
+          branch)
+            case "$ref_name" in
+              main)
+                # When CI runs on `main`, tag the image as `latest`.
+                IMAGE_TAG=latest
+                ;;
+              */merge)
+                # Github docs claim that ref_name is set to `123/merge` when
+                # building a PR, but in practice it seems to use the branch
+                # name instead.  If this case does occur at some point, we
+                # convert the name to `pr-123`.
+                IMAGE_TAG="pr-${ref_name%/merge}"
+                ;;
+              *)
+                # In all other cases, tag the image based on the ref name,
+                # replacing `/` with `-`.
+                IMAGE_TAG="${ref_name//\//-}"
+                ;;
+            esac
+            ;;
+          tag)
+            # Replace `/` with `-`, but otherwise use the tag name unchanged.
+            IMAGE_TAG="${ref_name//\//-}"
+            ;;
+        esac
+        echo "DOCKER_IMAGE_TAG=$IMAGE_TAG" >>$GITHUB_ENV
     - name: Build the Docker image
       run: |
-        echo "Building ${{env.OPENSUT_BASE_IMAGE_ID}}"
-        docker build . --file Dockerfile --tag ${{env.OPENSUT_BASE_IMAGE_ID}}
+        OPENSUT_IMAGE_ID="${{env.OPENSUT_BASE_IMAGE_ID}}:$DOCKER_IMAGE_TAG"
+        echo "Building $OPENSUT_IMAGE_ID"
+        docker build . --file Dockerfile --tag "$OPENSUT_IMAGE_ID"
     - name: Push the Docker image
-      run: docker push ${{env.OPENSUT_BASE_IMAGE_ID}}
+      run: |
+        OPENSUT_IMAGE_ID="${{env.OPENSUT_BASE_IMAGE_ID}}:$DOCKER_IMAGE_TAG"
+        docker push "$OPENSUT_IMAGE_ID"


### PR DESCRIPTION
This modifies the CI job that builds the docker image to use a different tag for the image depending on which git branch or tag is being built:

* When building `main`, tag the image `latest`.  This means once a PR is merged, the post-merge CI job will update `latest`.
* When building a git tag or branch, tag the image with the same name as the git tag/branch.  Any `/` characters (which aren't allowed in docker tag names) are replaced with `-`.
* When building a PR, tag the image `pr-123`.  This lets the developer pull the image for testing, but avoids overwriting `latest` with possibly broken code.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] My code matches the coding standards and I have ran the appropriate linters
- [ ] I included documentation updates for my code
- [ ] I extended the test suite and the tests run by the CI to cover my code
- [x] I assigned a Milestone to this PR
- [x] I assigned this PR to a Project
- [x] I assigned this PR appropriate Labels
